### PR TITLE
Fix OS fingerprinting bug

### DIFF
--- a/lib/ssh_scan/os/ubuntu.rb
+++ b/lib/ssh_scan/os/ubuntu.rb
@@ -6,7 +6,7 @@ module SSHScan
       end
 
       def cpe
-        "o:canonical:freebsd"
+        "o:canonical:ubuntu"
       end
     end
   end


### PR DESCRIPTION
Discovered a bug when running against scanme.nmap.org.  Found a typo in the Ubuntu OS fingerprinter.

    $ ./bin/ssh_scan -t scanme.nmap.org
    {
      "ssh_scan_version": "0.0.8",
      "hostname": "scanme.nmap.org",
      "ip": "45.33.32.156",
      "port": 22,
      "server_banner": "SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.7",
      "ssh_version": 2.0,
      "os": "ubuntu",
      "os_cpe": "o:canonical:freebsd",
      "ssh_lib": "openssh",
      "ssh_lib_cpe": "a:openssh:openssh",
      "key_algorithms": [
        "curve25519-sha256@libssh.org",
        "ecdh-sha2-nistp256",
        "ecdh-sha2-nistp384",
        "ecdh-sha2-nistp521",
        "diffie-hellman-group-exchange-sha256",
        "diffie-hellman-group-exchange-sha1",
        "diffie-hellman-group14-sha1",
        "diffie-hellman-group1-sha1"
      ],
      "server_host_key_algorithms": [
        "ssh-rsa",
        "ssh-dss",
        "ecdsa-sha2-nistp256",
        "ssh-ed25519"
      ],
      "encryption_algorithms_client_to_server": [
        "aes128-ctr",
        "aes192-ctr",
        "aes256-ctr",
        "arcfour256",
        "arcfour128",
        "aes128-gcm@openssh.com",
        "aes256-gcm@openssh.com",
        "chacha20-poly1305@openssh.com",
        "aes128-cbc",
        "3des-cbc",
        "blowfish-cbc",
        "cast128-cbc",
        "aes192-cbc",
        "aes256-cbc",
        "arcfour",
        "rijndael-cbc@lysator.liu.se"
      ],
      "encryption_algorithms_server_to_client": [
        "aes128-ctr",
        "aes192-ctr",
        "aes256-ctr",
        "arcfour256",
        "arcfour128",
        "aes128-gcm@openssh.com",
        "aes256-gcm@openssh.com",
        "chacha20-poly1305@openssh.com",
        "aes128-cbc",
        "3des-cbc",
        "blowfish-cbc",
        "cast128-cbc",
        "aes192-cbc",
        "aes256-cbc",
        "arcfour",
        "rijndael-cbc@lysator.liu.se"
      ],
      "mac_algorithms_client_to_server": [
        "hmac-md5-etm@openssh.com",
        "hmac-sha1-etm@openssh.com",
        "umac-64-etm@openssh.com",
        "umac-128-etm@openssh.com",
        "hmac-sha2-256-etm@openssh.com",
        "hmac-sha2-512-etm@openssh.com",
        "hmac-ripemd160-etm@openssh.com",
        "hmac-sha1-96-etm@openssh.com",
        "hmac-md5-96-etm@openssh.com",
        "hmac-md5",
        "hmac-sha1",
        "umac-64@openssh.com",
        "umac-128@openssh.com",
        "hmac-sha2-256",
        "hmac-sha2-512",
        "hmac-ripemd160",
        "hmac-ripemd160@openssh.com",
        "hmac-sha1-96",
        "hmac-md5-96"
      ],
      "mac_algorithms_server_to_client": [
        "hmac-md5-etm@openssh.com",
        "hmac-sha1-etm@openssh.com",
        "umac-64-etm@openssh.com",
        "umac-128-etm@openssh.com",
        "hmac-sha2-256-etm@openssh.com",
        "hmac-sha2-512-etm@openssh.com",
        "hmac-ripemd160-etm@openssh.com",
        "hmac-sha1-96-etm@openssh.com",
        "hmac-md5-96-etm@openssh.com",
        "hmac-md5",
        "hmac-sha1",
        "umac-64@openssh.com",
        "umac-128@openssh.com",
        "hmac-sha2-256",
        "hmac-sha2-512",
        "hmac-ripemd160",
        "hmac-ripemd160@openssh.com",
        "hmac-sha1-96",
        "hmac-md5-96"
      ],
      "compression_algorithms_client_to_server": [
        "none",
        "zlib@openssh.com"
      ],
      "compression_algorithms_server_to_client": [
        "none",
        "zlib@openssh.com"
      ],
      "languages_client_to_server": [

      ],
      "languages_server_to_client": [

      ],
      "auth_methods": [
        "publickey",
        "password"
      ],
      "fingerprints": {
        "md5": "35:79:63:bc:9c:5e:df:3f:65:d3:db:01:34:3c:34:05",
        "sha1": "07:3e:e6:74:c9:e3:ab:0e:f8:92:76:5a:ed:56:3a:d1:9b:23:10:e9",
        "sha256": "52:5c:c1:dc:ea:8a:7b:a5:d5:1e:be:81:f6:d7:6d:60:43:40:78:dd:4f:9a:9d:06:cb:74:ff:6d:07:4e:64:d6"
      },
      "compliance": {
        "policy": "Mozilla Modern",
        "compliant": false,
        "recommendations": [
          "Remove these Key Exchange Algos: diffie-hellman-group-exchange-sha1, diffie-hellman-group14-sha1, diffie-hellman-group1-sha1",
          "Remove these MAC Algos: hmac-md5-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64-etm@openssh.com, hmac-ripemd160-etm@openssh.com, hmac-sha1-96-etm@openssh.com, hmac-md5-96-etm@openssh.com, hmac-md5, hmac-sha1, umac-64@openssh.com, hmac-ripemd160, hmac-ripemd160@openssh.com, hmac-sha1-96, hmac-md5-96",
          "Remove these Encryption Ciphers: arcfour256, arcfour128, aes128-cbc, 3des-cbc, blowfish-cbc, cast128-cbc, aes192-cbc, aes256-cbc, arcfour, rijndael-cbc@lysator.liu.se"
        ]
      }
    }