### PR TITLE
removed extra space which was resulting is server panic

### DIFF
--- a/lib/ssh_scan/policy_manager.rb
+++ b/lib/ssh_scan/policy_manager.rb
@@ -103,10 +103,10 @@ module SSHScan
       recommendations = []
 
       # Add these items to be compliant
-      recommendations << "Add these Key Exchange Algos: #{missing_policy_kex.join(", ")}" unless missing_policy_kex.empty?
-      recommendations << "Add these MAC Algos: #{missing_policy_macs.join(", ")}" unless missing_policy_macs.empty?
-      recommendations << "Add these Encryption Ciphers: #{missing_policy_encryption.join(", ")}" unless missing_policy_encryption.empty?
-      recommendations << "Add these Compression Algos: #{missing_policy_compression.join(", ")}" unless missing_policy_compression.empty?
+      recommendations << "Add these Key Exchange Algos: #{missing_policy_kex.join(",")}" unless missing_policy_kex.empty?
+      recommendations << "Add these MAC Algos: #{missing_policy_macs.join(",")}" unless missing_policy_macs.empty?
+      recommendations << "Add these Encryption Ciphers: #{missing_policy_encryption.join(",")}" unless missing_policy_encryption.empty?
+      recommendations << "Add these Compression Algos: #{missing_policy_compression.join(",")}" unless missing_policy_compression.empty?
 
       # Remove these items to be compliant
       recommendations << "Remove these Key Exchange Algos: #{out_of_policy_kex.join(", ")}" unless out_of_policy_kex.empty?


### PR DESCRIPTION
Extra space in list of entries to be added was present if someone copy pastes the list in sshd_config file in hope of getting the right configuration this results in a ssh server launch failure.

Similar space in list of stuff to removed doesn't matters as they will anyways be required to be removed manually.

Hope this helps
