### PR TITLE
Build docker container in travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ rvm:
   - 2.1.0
   - 2.0.0
   - ruby-head
+services:
+  - docker
+script:
+  - docker build -t mozilla/ssh_scan .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby
+MAINTAINER Jonathan Claudius
+ENV PROJECT=github.com/mozilla/ssh_scan
+
+RUN mkdir /app
+ADD . /app
+WORKDIR /app
+
+RUN gem install bundler
+RUN bundle install
+CMD /app/bin/ssh_scan


### PR DESCRIPTION
If this works, we could add automated publication of the container in the mozilla org on dockerhub.