### PR TITLE
Add support for custom ports in input file and support rescans

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Run `ssh_scan -h` to get this
         -f, --file [FilePath]            File Path of the file containing IP/Range/Hostnames to scan
         -T, --timeout [seconds]          Timeout per connect after which ssh_scan gives up on the host
         -o, --output [FilePath]          File to write JSON output to
+        -O, --from_json [FilePath]       File to read JSON output from
         -p, --port [PORT]                Port (Default: 22)
         -P, --policy [FILE]              Custom policy file (Default: Mozilla Modern)
             --threads [NUMBER]           Number of worker threads (Default: 5)
@@ -79,6 +80,7 @@ Run `ssh_scan -h` to get this
       ssh_scan -t ::1 -T 5
       ssh_scan -f hosts.txt
       ssh_scan -o output.json
+      ssh_scan -O output.json -o rescan_output.json
       ssh_scan -t 192.168.1.1 -p 22222
       ssh_scan -t 192.168.1.1 -P custom_policy.yml
       ssh_scan -t 192.168.1.1 --unit-test -P custom_policy.yml

--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -3,14 +3,14 @@
 # Path setting slight of hand
 $:.unshift File.join(File.dirname(__FILE__), "../lib")
 
-require 'ssh_scan'
-require 'optparse'
+require 'json'
 require 'netaddr'
+require 'optparse'
+require 'ssh_scan'
 
 #Default options
 options = {
-  :targets => [],
-  :port => 22,
+  :sockets => [],
   :policy => File.expand_path("../../policies/mozilla_modern.yml", __FILE__),
   :unit_test => false,
   :timeout => 2,
@@ -26,7 +26,7 @@ opt_parser = OptionParser.new do |opts|
   opts.on("-t", "--target [IP/Range/Hostname]", Array,
           "IP/Ranges/Hostname to scan") do |ips|
     ips.each do |ip|
-      options[:targets] += target_parser.enumerateIPRange(ip)
+      options[:sockets] += target_parser.enumerateIPRange(ip)
     end
   end
 
@@ -37,8 +37,10 @@ opt_parser = OptionParser.new do |opts|
       exit
     end
     File.open(file).each do |line|
-      line.chomp.split(',').each do |ip|
-        options[:targets] += target_parser.enumerateIPRange(ip)
+      line.chomp.split(',').each do |socket|
+        ip, port = socket.chomp.split(':')
+        port = port.nil? ? 22 : port
+        options[:sockets] += target_parser.enumerateIPRange(ip, port)
       end
     end
   end
@@ -48,6 +50,20 @@ opt_parser = OptionParser.new do |opts|
     options[:timeout] = timeout.to_i
   end
 
+  opts.on("-O", "--from_json [FilePath]",
+          "File to read JSON output from") do |file|
+    unless File.exists?(file)
+      puts "\nReason: Invalid file"
+      exit
+    end
+    file = open(file)
+    json = file.read
+    parsed_json = JSON.parse(json)
+    parsed_json.each do |host|
+      options[:sockets] += target_parser.enumerateIPRange(host['ip'], host['port'])
+    end
+  end
+
   opts.on("-o", "--output [FilePath]",
           "File to write JSON output to") do |file|
     $stdout.reopen(file, "w")
@@ -55,7 +71,9 @@ opt_parser = OptionParser.new do |opts|
 
   opts.on("-p", "--port [PORT]",
           "Port (Default: 22)") do |port|
-    options[:port] = port.to_i
+    socket = options[:sockets].shift
+    ip = socket.chomp.split(':').shift
+    options[:sockets] += target_parser.enumerateIPRange(ip, port)
   end
 
   opts.on("-P", "--policy [FILE]",
@@ -88,6 +106,7 @@ opt_parser = OptionParser.new do |opts|
     puts "  ssh_scan -t ::1 -T 5"
     puts "  ssh_scan -f hosts.txt"
     puts "  ssh_scan -o output.json"
+    puts "  ssh_scan -O output.json -o rescan_output.json"
     puts "  ssh_scan -t 192.168.1.1 -p 22222"
     puts "  ssh_scan -t 192.168.1.1 -P custom_policy.yml"
     puts "  ssh_scan -t 192.168.1.1 --unit-test -P custom_policy.yml"
@@ -98,24 +117,28 @@ end
 
 opt_parser.parse!
 
-if options[:targets].nil?
+if options[:sockets].nil?
   puts opt_parser.help
   puts "\nReason: no target specified"
   exit 1
 end
 
-options[:targets].each do |target|
-  unless target.ip_addr? || target.fqdn?
+options[:sockets].each do |socket|
+  ip, port = socket.chomp.split(':')
+  unless ip.ip_addr? || ip.fqdn?
     puts opt_parser.help
-    puts "\nReason: #{options[:targets]} is not a valid target"
+    puts "\nReason: #{socket} is not a valid target"
     exit 1
   end
 end
 
-unless (0..65535).include?(options[:port])
-  puts opt_parser.help
-  puts "\nReason: port supplied is not within acceptable range"
-  exit 1
+options[:sockets].each do |socket|
+  ip, port = socket.chomp.split(':')
+  unless (0..65535).include?(port.to_i)
+    puts opt_parser.help
+    puts "\nReason: port supplied is not within acceptable range"
+    exit 1
+  end
 end
 
 unless File.exists?(options[:policy])

--- a/lib/ssh_scan/target_parser.rb
+++ b/lib/ssh_scan/target_parser.rb
@@ -3,9 +3,10 @@ require 'string_ext'
 
 module SSHScan
   class TargetParser
-    def enumerateIPRange(ip)
+    def enumerateIPRange(ip, port = "22")
       if ip.fqdn?
-        return [ip]
+        socket = ip.concat(":").concat(port.to_s)
+        return [socket]
       else
         if ip.include? "-"
           octets = ip.split('.')
@@ -13,15 +14,18 @@ module SSHScan
           lower = NetAddr::CIDR.create(octets.join('.') + "." + range[0])
           upper = NetAddr::CIDR.create(octets.join('.') + "." + range[1])
           ip_array = NetAddr.range(lower, upper,:Inclusive => true)
+          ip_array.map! { |ip| ip.concat(":").concat(port.to_s) }
           return ip_array
         elsif ip.include? "/"
           cidr = NetAddr::CIDR.create(ip)
           ip_array = cidr.enumerate
           ip_array.delete(cidr.network)
           ip_array.delete(cidr.last)
+          ip_array.map! { |ip| ip.concat(":").concat(port.to_s) }
           return ip_array
         else
-          return [ip]
+          socket = ip.concat(":").concat(port.to_s)
+          return [socket]
         end
       end
     end

--- a/spec/ssh_scan/integration.sh
+++ b/spec/ssh_scan/integration.sh
@@ -44,3 +44,14 @@ else
   echo "Integration Test #4: Fail"
   exit 1
 fi
+
+# Integration Test #5 (File Input + File Output)
+./bin/ssh_scan -t github.com -p 22 -o output.json
+./bin/ssh_scan -O output.json -o rescan_output.json
+if [ $? -eq 0 ]
+then
+  echo "Integration Test #5: Pass"
+else
+  echo "Integration Test #5: Fail"
+  exit 1
+fi

--- a/spec/ssh_scan/target_parser_rspec.rb
+++ b/spec/ssh_scan/target_parser_rspec.rb
@@ -5,28 +5,28 @@ describe SSHScan::TargetParser do
   context "FQDN" do
     it "should return an array containing that URL" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("github.com")).to eq(["github.com"])
+      expect(target_parser.enumerateIPRange("github.com")).to eq(["github.com:22"])
     end
   end
 
   context "IPv4" do
     it "should return an array containing that IPv4" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("192.168.1.1")).to eq(["192.168.1.1"])
+      expect(target_parser.enumerateIPRange("192.168.1.1")).to eq(["192.168.1.1:22"])
     end
   end
 
   context "IPv4 Range seperated by '-'" do
     it "should return an array containing all the IPv4 in that range" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("192.168.1.1-2")).to eq(["192.168.1.1", "192.168.1.2"])
+      expect(target_parser.enumerateIPRange("192.168.1.1-2")).to eq(["192.168.1.1:22", "192.168.1.2:22"])
     end
   end
 
   context "IPv4 with subnet mask specified" do
     it "should return an array containing all the IPv4 in that range" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("192.168.1.0/30")).to eq(["192.168.1.1", "192.168.1.2"])
+      expect(target_parser.enumerateIPRange("192.168.1.0/30")).to eq(["192.168.1.1:22", "192.168.1.2:22"])
     end
   end
 end

--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('net-ssh')
   s.add_dependency('netaddr')
   s.add_dependency('timeout')
+  s.add_dependency('json')
   s.add_development_dependency('pry')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
Fixes https://github.com/mozilla/ssh_scan/issues/99
This PR adds support for custom ports in input file. For example,
```bash
192.168.1.1,192.168.1.1:2222,192.168.1.2
```
- Added support for using output file as input for rescans  (https://github.com/mozilla/ssh_scan/issues/101).

Now we can use 
```bash
ssh_scan -O output.json -o rescan_output.json
```
How about this? @claudijd 