### PR TITLE
Added auth_methods as a policy control. Fixes #139

### DIFF
--- a/lib/ssh_scan/policy.rb
+++ b/lib/ssh_scan/policy.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 module SSHScan
   class Policy
-    attr_reader :name, :kex, :macs, :encryption, :compression, :references
+    attr_reader :name, :kex, :macs, :encryption, :compression, :references, :auth_methods
 
     def initialize(opts = {})
       @name = opts['name'] || []
@@ -11,6 +11,7 @@ module SSHScan
       @encryption = opts['encryption'] || []
       @compression = opts['compression'] || []
       @references = opts['references'] || []
+      @auth_methods = opts['auth_methods'] || []
     end
 
     def self.from_file(file)

--- a/lib/ssh_scan/policy_manager.rb
+++ b/lib/ssh_scan/policy_manager.rb
@@ -88,6 +88,20 @@ module SSHScan
       return outliers
     end
 
+    def out_of_policy_auth_methods
+      target_auth_methods = @result["auth_methods"]
+      outliers = []
+
+      if not @policy.auth_methods.empty?
+        target_auth_methods.each do |auth_method|
+          if not @policy.auth_methods.include?(auth_method)
+            outliers << auth_method
+          end
+        end
+      end
+      return outliers
+    end
+
     def compliant?
       out_of_policy_encryption.empty? &&
       out_of_policy_macs.empty? &&
@@ -96,7 +110,8 @@ module SSHScan
       missing_policy_encryption.empty? &&
       missing_policy_macs.empty? &&
       missing_policy_kex.empty? &&
-      missing_policy_compression.empty?
+      missing_policy_compression.empty? &&
+      out_of_policy_auth_methods.empty?
     end
 
     def recommendations
@@ -113,6 +128,7 @@ module SSHScan
       recommendations << "Remove these MAC Algos: #{out_of_policy_macs.join(", ")}" unless out_of_policy_macs.empty?
       recommendations << "Remove these Encryption Ciphers: #{out_of_policy_encryption.join(", ")}" unless out_of_policy_encryption.empty?
       recommendations << "Remove these Compression Algos: #{out_of_policy_compression.join(", ")}" unless out_of_policy_compression.empty?
+      recommendations << "Remove these Authentication Methods: #{out_of_policy_auth_methods.join(", ")}" unless out_of_policy_auth_methods.empty?
       return recommendations
     end
 

--- a/spec/ssh_scan/policy_manager_spec.rb
+++ b/spec/ssh_scan/policy_manager_spec.rb
@@ -168,4 +168,28 @@ describe SSHScan::PolicyManager do
     end
   end
 
+  context "when checking the allowed auth methods" do
+    yaml_string = "---\nname: Mozilla Intermediate\nkex:\n" +
+                  "- diffie-hellman-group-exchange-sha256\n" +
+                  "encryption:\n- aes256-ctr\n- aes192-ctr\n" +
+                  "- aes128-ctr\nmacs:\n- hmac-sha2-512\n" +
+                  "- hmac-sha2-256\ncompression:\n- none\n" +
+                  "- zlib@openssh.com\n" +
+                  "references:\n- https://wiki.mozilla.org/Security/Guidelines/OpenSSH\n" +
+                  "auth_methods:\n- publickey\n"
+    result = {
+                "auth_methods" => [
+                  "publickey",
+                  "password",
+                ]
+              }
+
+    it "should load all the attributes properly" do
+      policy = SSHScan::Policy.from_string(yaml_string)
+      policy_manager = SSHScan::PolicyManager.new(result, policy)
+      outliers = ["password"]
+      expect(policy_manager.out_of_policy_auth_methods()).to eql(outliers)
+    end
+  end
+
 end


### PR DESCRIPTION
To add a whitelist of auth_methods, we just need to add the below sample block to the `policy.yml` file:

```yml
auth_methods:
- publickey
- password
```

If no whitelist of auth_methods is provided, it assumes all `auth_methods` are valid.