### PR TITLE
Add publickey to auth_methods default policies

### DIFF
--- a/policies/mozilla_intermediate.yml
+++ b/policies/mozilla_intermediate.yml
@@ -1,5 +1,7 @@
 ---
 name: Mozilla Intermediate
+auth_methods:
+- publickey
 kex:
 - diffie-hellman-group-exchange-sha256
 encryption:

--- a/policies/mozilla_modern.yml
+++ b/policies/mozilla_modern.yml
@@ -1,5 +1,7 @@
 ---
 name: Mozilla Modern
+auth_methods:
+- publickey
 kex:
 - curve25519-sha256@libssh.org
 - ecdh-sha2-nistp521


### PR DESCRIPTION
Because #42 happened, adding publickey requirements to both intermediate and modern policy defaults.  Many thanks to @yashmehrotra for making that happen!

I also ran a test case on this here, looks good....

    [
      {
        "ssh_scan_version": "0.0.11",
        "ip": "192.168.0.34",
        "port": "22",
        "server_banner": "SSH-2.0-OpenSSH_7.2p2 Debian-5",
        "ssh_version": 2.0,
        "os": "debian",
        "os_cpe": "o:debian:debian",
        "ssh_lib": "openssh",
        "ssh_lib_cpe": "a:openssh:openssh:7.2p2",
        "cookie": "06d4d24ad7cdeebe2a38e682adede6f8",
        "key_algorithms": [
          "curve25519-sha256@libssh.org",
          "ecdh-sha2-nistp256",
          "ecdh-sha2-nistp384",
          "ecdh-sha2-nistp521",
          "diffie-hellman-group-exchange-sha256",
          "diffie-hellman-group14-sha1"
        ],
        "server_host_key_algorithms": [
          "ssh-rsa",
          "rsa-sha2-512",
          "rsa-sha2-256",
          "ecdsa-sha2-nistp256",
          "ssh-ed25519"
        ],
        "encryption_algorithms_client_to_server": [
          "chacha20-poly1305@openssh.com",
          "aes128-ctr",
          "aes192-ctr",
          "aes256-ctr",
          "aes128-gcm@openssh.com",
          "aes256-gcm@openssh.com"
        ],
        "encryption_algorithms_server_to_client": [
          "chacha20-poly1305@openssh.com",
          "aes128-ctr",
          "aes192-ctr",
          "aes256-ctr",
          "aes128-gcm@openssh.com",
          "aes256-gcm@openssh.com"
        ],
        "mac_algorithms_client_to_server": [
          "umac-64-etm@openssh.com",
          "umac-128-etm@openssh.com",
          "hmac-sha2-256-etm@openssh.com",
          "hmac-sha2-512-etm@openssh.com",
          "hmac-sha1-etm@openssh.com",
          "umac-64@openssh.com",
          "umac-128@openssh.com",
          "hmac-sha2-256",
          "hmac-sha2-512",
          "hmac-sha1"
        ],
        "mac_algorithms_server_to_client": [
          "umac-64-etm@openssh.com",
          "umac-128-etm@openssh.com",
          "hmac-sha2-256-etm@openssh.com",
          "hmac-sha2-512-etm@openssh.com",
          "hmac-sha1-etm@openssh.com",
          "umac-64@openssh.com",
          "umac-128@openssh.com",
          "hmac-sha2-256",
          "hmac-sha2-512",
          "hmac-sha1"
        ],
        "compression_algorithms_client_to_server": [
          "none",
          "zlib@openssh.com"
        ],
        "compression_algorithms_server_to_client": [
          "none",
          "zlib@openssh.com"
        ],
        "languages_client_to_server": [

        ],
        "languages_server_to_client": [

        ],
        "hostname": "",
        "auth_methods": [
          "publickey",
          "password"
        ],
        "fingerprints": {
          "md5": "55:f1:60:bb:8e:94:30:75:8b:56:6f:ec:a1:92:6c:d7",
          "sha1": "d5:a5:68:27:c1:12:1b:2b:40:0a:4d:e6:d5:95:fd:6f:83:aa:02:2b",
          "sha256": "84:95:5e:c8:33:13:d3:b9:24:a7:10:36:59:38:bc:53:79:88:ca:09:37:ee:f3:3c:35:f8:d8:b4:50:a9:d4:84"
        },
        "compliance": {
          "policy": "Mozilla Modern",
          "compliant": false,
          "recommendations": [
            "Remove these Key Exchange Algos: diffie-hellman-group14-sha1",
            "Remove these MAC Algos: umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1",
            "Remove these Authentication Methods: password"
          ],
          "references": [
            "https://wiki.mozilla.org/Security/Guidelines/OpenSSH"
          ]
        }
      }
    ]