### PR TITLE
Provide compliance results with partial success

### DIFF
--- a/lib/ssh_scan/policy_manager.rb
+++ b/lib/ssh_scan/policy_manager.rb
@@ -89,6 +89,8 @@ module SSHScan
     end
 
     def out_of_policy_auth_methods
+      return [] if @result["auth_methods"].nil?
+
       target_auth_methods = @result["auth_methods"]
       outliers = []
 

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -76,13 +76,25 @@ module SSHScan
            "sha1" => fingerprint_sha1,
            "sha256" => fingerprint_sha256,
           }
-          # Do this only when no errors were reported
-          unless policy.nil?
-            policy_mgr = SSHScan::PolicyManager.new(result, policy)
-            result['compliance'] = policy_mgr.compliance_results
-          end
         end
       end
+
+      # Do this only when no errors were reported
+      if !policy.nil? &&
+         !result[:key_algorithms].nil? &&
+         !result[:server_host_key_algorithms].nil? &&
+         !result[:encryption_algorithms_client_to_server].nil? &&
+         !result[:encryption_algorithms_server_to_client].nil? &&
+         !result[:mac_algorithms_client_to_server].nil? &&
+         !result[:mac_algorithms_server_to_client].nil? &&
+         !result[:compression_algorithms_client_to_server].nil? &&
+         !result[:compression_algorithms_server_to_client].nil? &&
+         !result[:languages_client_to_server].nil? &&
+         !result[:languages_server_to_client].nil?
+        policy_mgr = SSHScan::PolicyManager.new(result, policy)
+        result['compliance'] = policy_mgr.compliance_results
+      end
+
       return result
     end
 


### PR DESCRIPTION
In cases when net-ssh bonks at trying to actually negotiate a session and is disconnected, let's still provide compliance results for information we do have.