### PR TITLE
fix nit in #130

### DIFF
--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -10,7 +10,7 @@ require 'ssh_scan'
 
 #Default options
 options = {
-  :sockets => [],
+  :sockets => Set.new,
   :policy => File.expand_path("../../policies/mozilla_modern.yml", __FILE__),
   :unit_test => false,
   :timeout => 2,
@@ -60,7 +60,7 @@ opt_parser = OptionParser.new do |opts|
     json = file.read
     parsed_json = JSON.parse(json)
     parsed_json.each do |host|
-      options[:sockets] += target_parser.enumerateIPRange(host['ip'], host['port'])
+      options[:sockets] += target_parser.enumerateIPRange(host['ip'], host['port'], true)
     end
   end
 
@@ -71,11 +71,11 @@ opt_parser = OptionParser.new do |opts|
 
   opts.on("-p", "--port [PORT]", Array,
           "Port (Default: 22)") do |ports|
-    temp = []
+    temp = Set.new
     options[:sockets].each do |socket|
       ports.each do |port|
         ip = socket.chomp.split(':').shift
-        temp += target_parser.enumerateIPRange(ip, port)
+        temp += target_parser.enumerateIPRange(ip, port, true)
       end
     end
     options[:sockets] += temp
@@ -121,6 +121,7 @@ opt_parser = OptionParser.new do |opts|
 end
 
 opt_parser.parse!
+options[:sockets] = target_parser.sanitizeIPRange(options[:sockets])
 
 if options[:sockets].nil?
   puts opt_parser.help

--- a/lib/ssh_scan/target_parser.rb
+++ b/lib/ssh_scan/target_parser.rb
@@ -1,12 +1,13 @@
 require 'netaddr'
 require 'string_ext'
+require 'set'
 
 module SSHScan
   class TargetParser
-    def enumerateIPRange(ip, port = "22")
+    def enumerateIPRange(ip, port = "22", port_append = false)
       if ip.fqdn?
-        socket = ip.concat(":").concat(port.to_s)
-        return [socket]
+        socket = port_append ? ip.concat(":").concat(port.to_s) : ip
+        return [socket].to_set
       else
         if ip.include? "-"
           octets = ip.split('.')
@@ -14,20 +15,36 @@ module SSHScan
           lower = NetAddr::CIDR.create(octets.join('.') + "." + range[0])
           upper = NetAddr::CIDR.create(octets.join('.') + "." + range[1])
           ip_array = NetAddr.range(lower, upper,:Inclusive => true)
-          ip_array.map! { |ip| ip.concat(":").concat(port.to_s) }
-          return ip_array
+          ip_array.map! { |ip| port_append ? ip.concat(":").concat(port.to_s) : ip }
+          return ip_array.to_set
         elsif ip.include? "/"
           cidr = NetAddr::CIDR.create(ip)
           ip_array = cidr.enumerate
           ip_array.delete(cidr.network)
           ip_array.delete(cidr.last)
-          ip_array.map! { |ip| ip.concat(":").concat(port.to_s) }
-          return ip_array
+          ip_array.map! { |ip| port_append ? ip.concat(":").concat(port.to_s) : ip }
+          return ip_array.to_set
         else
-          socket = ip.concat(":").concat(port.to_s)
-          return [socket]
+          socket = port_append ? ip.concat(":").concat(port.to_s) : ip
+          return [socket].to_set
         end
       end
+    end
+
+    # Remove instances of ip, where ip:port already exist.
+    # This would mean that port was somehow passed. Otherwise,
+    # make ip = ip:22
+    def sanitizeIPRange(ip_range)
+      new_ip_range = ip_range.to_a
+      ip_range.each do |old_ip|
+        next if !old_ip.include?(':')
+        ip_part = old_ip.split(':').first
+        if old_ip.include?(':') and new_ip_range.include?(ip_part)
+          new_ip_range.delete(ip_part)
+        end
+      end
+      new_ip_range = new_ip_range.map { |ip| ip.include?(':') ? ip : ip + ":22" }
+      return new_ip_range.to_set
     end
   end
 end

--- a/spec/ssh_scan/target_parser_spec.rb
+++ b/spec/ssh_scan/target_parser_spec.rb
@@ -1,32 +1,37 @@
 require 'rspec'
 require 'ssh_scan/target_parser'
+require 'set'
 
 describe SSHScan::TargetParser do
   context "FQDN" do
     it "should return an array containing that URL" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("github.com")).to eq(["github.com:22"])
+      unsanitized = target_parser.enumerateIPRange("github.com")
+      expect(target_parser.sanitizeIPRange(unsanitized)).to eq(["github.com:22"].to_set)
     end
   end
 
   context "IPv4" do
     it "should return an array containing that IPv4" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("192.168.1.1")).to eq(["192.168.1.1:22"])
+      unsanitized = target_parser.enumerateIPRange("192.168.1.1")
+      expect(target_parser.sanitizeIPRange(unsanitized)).to eq(["192.168.1.1:22"].to_set)
     end
   end
 
   context "IPv4 Range seperated by '-'" do
     it "should return an array containing all the IPv4 in that range" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("192.168.1.1-2")).to eq(["192.168.1.1:22", "192.168.1.2:22"])
+      unsanitized = target_parser.enumerateIPRange("192.168.1.1-2")
+      expect(target_parser.sanitizeIPRange(unsanitized)).to eq(["192.168.1.1:22", "192.168.1.2:22"].to_set)
     end
   end
 
   context "IPv4 with subnet mask specified" do
     it "should return an array containing all the IPv4 in that range" do
       target_parser = SSHScan::TargetParser.new()
-      expect(target_parser.enumerateIPRange("192.168.1.0/30")).to eq(["192.168.1.1:22", "192.168.1.2:22"])
+      unsanitized = target_parser.enumerateIPRange("192.168.1.0/30")
+      expect(target_parser.sanitizeIPRange(unsanitized)).to eq(["192.168.1.1:22", "192.168.1.2:22"].to_set)
     end
   end
 end


### PR DESCRIPTION
@claudijd 

I tried ssh_scan -t ip -p 9999, and upon inspecting options[:sockets] it looked something like ["ip:22", "ip:9999"], when it should've been ["ip:9999"].