### PR TITLE
A shim to try out mongodb as a DB store

### DIFF
--- a/lib/ssh_scan.rb
+++ b/lib/ssh_scan.rb
@@ -2,6 +2,7 @@
 require 'bindata'
 require 'timeout'
 require 'resolv'
+require 'mongo'
 
 #Internal Deps
 require 'ssh_scan/version'

--- a/lib/ssh_scan/client.rb
+++ b/lib/ssh_scan/client.rb
@@ -61,7 +61,7 @@ module SSHScan
       end
 
       # Assemble and print results
-      result[:server_banner] = @server_banner
+      result[:server_banner] = @server_banner.to_s
       result[:ssh_version] = @server_banner.ssh_version
       result[:os] = @server_banner.os_guess.common
       result[:os_cpe] = @server_banner.os_guess.cpe
@@ -76,7 +76,7 @@ module SSHScan
         @sock = nil
         return result
       end
-      
+
       resp += @sock.read(resp.unpack("N").first)
       @sock.close
 

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -106,7 +106,10 @@ module SSHScan
       threads = opts[:threads] || 5
       logger = opts[:logger]
 
-      results = []
+      #results = []
+
+      mongo_client = Mongo::Client.new('mongodb://127.0.0.1:27017/ssh_scan')
+      collection = mongo_client[:scans]
 
       work_queue = Queue.new
       sockets.each {|x| work_queue.push x }
@@ -115,7 +118,8 @@ module SSHScan
           begin
             while socket = work_queue.pop(true)
               logger.info("Started ssh_scan of #{socket}")
-              results << scan_target(socket, opts)
+              result = scan_target(socket, opts)
+              collection.insert_one(result)
               logger.info("Completed ssh_scan of #{socket}")
             end
           rescue ThreadError => e
@@ -125,7 +129,7 @@ module SSHScan
       end
       workers.map(&:join)
 
-      return results
+      #return results
     end
   end
 end

--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('netaddr')
   s.add_dependency('net-ssh')
   s.add_development_dependency('pry')
+  s.add_development_dependency('mongo')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')
   s.add_development_dependency('rake', '~> 10.3')


### PR DESCRIPTION
This is not landable code, just wanted to put an example up here so we have it for later and it's not forgotten.

Was sorta handy in finding some ssh-scan bugs when taking our JSON output and trying to stuff into mongo.

My only complaint here is that Mongo seems like a pretty heavy dependancy...

# Server
brew install mongodb
mkdir -p /data/db
mongod

# Client
gem install mongodb
