### PR TITLE
Fix banner class bug

### DIFF
--- a/lib/ssh_scan/client.rb
+++ b/lib/ssh_scan/client.rb
@@ -61,7 +61,7 @@ module SSHScan
       end
 
       # Assemble and print results
-      result[:server_banner] = @server_banner
+      result[:server_banner] = @server_banner.to_s
       result[:ssh_version] = @server_banner.ssh_version
       result[:os] = @server_banner.os_guess.common
       result[:os_cpe] = @server_banner.os_guess.cpe
@@ -76,7 +76,7 @@ module SSHScan
         @sock = nil
         return result
       end
-      
+
       resp += @sock.read(resp.unpack("N").first)
       @sock.close
 


### PR DESCRIPTION
The bug here is that banner was not being output as a string, it was output as a Klass.to_s equivalent, which was not ideal, but it was caught when trying to stuff into mongo