### PR TITLE
SQLite prototype shim example

### DIFF
--- a/lib/ssh_scan/fingerprint_database.rb
+++ b/lib/ssh_scan/fingerprint_database.rb
@@ -1,0 +1,39 @@
+require 'sqlite3'
+
+module SSHScan
+  class FingerprintDatabase
+    def initialize(database_name)
+      if File.exists?(database_name)
+        @db = ::SQLite3::Database.open(database_name)
+      else
+        @db = ::SQLite3::Database.new(database_name)
+        self.create_schema
+      end
+    end
+
+    def create_schema
+      @db.execute <<-SQL
+        create table fingerprints (
+          fingerprint varchar(100),
+          ip varchar(100)
+        );
+      SQL
+    end
+
+    def clear_fingerprints(ip)
+      @db.execute "delete from fingerprints where ip like ( ? )", [ip]
+    end
+
+    def add_fingerprint(fingerprint, ip)
+      @db.execute "insert into fingerprints values ( ?, ? )", [fingerprint, ip]
+    end
+
+    def find_fingerprints(fingerprint)
+      ips = []
+      @db.execute( "select * from fingerprints where fingerprint like ( ? )", [fingerprint] ) do |row|
+        ips << row[1]
+      end
+      return ips
+    end
+  end
+end

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require 'ssh_scan/client'
 require 'ssh_scan/crypto'
+require 'ssh_scan/fingerprint_database'
 require 'net/ssh'
 
 module SSHScan
@@ -78,6 +79,25 @@ module SSHScan
             "sha1" => pkey.fingerprint_sha1,
             "sha256" => pkey.fingerprint_sha256,
           }
+
+          fingerprint_db = SSHScan::FingerprintDatabase.new("./database/default.db")
+
+          # Need to remove old fingerprints before we add new ones
+          fingerprint_db.clear_fingerprints(result[:ip])
+
+          result['duplicate_fingerprints'] = []
+
+          result['fingerprints'].values.each do |fingerprint|
+            # Add any ips that are reusing these fingerprints
+            fingerprint_db.find_fingerprints(fingerprint).each do |other_ip|
+              result['duplicate_fingerprints'] << other_ip
+            end
+
+            # Add the new fingerprint to the database
+            fingerprint_db.add_fingerprint(fingerprint, result[:ip])
+          end
+
+          result['duplicate_fingerprints'].uniq!
         end
       end
 

--- a/spec/ssh_scan/fingerprint_database_spec.rb
+++ b/spec/ssh_scan/fingerprint_database_spec.rb
@@ -1,0 +1,44 @@
+require 'rspec'
+require 'tempfile'
+require 'ssh_scan/fingerprint_database'
+
+describe SSHScan::FingerprintDatabase do
+  context "when initializing a new FingerprintDatabase" do
+    it "should create a new DB on disk if it doesn't exist" do
+      file_name = "test.db"
+
+      #start with a known good state
+      File.unlink(file_name) if File.exists?(file_name)
+
+      expect(File.exist?(file_name)).to eql(false)
+      database = SSHScan::FingerprintDatabase.new(file_name)
+      expect(database).to be_kind_of(SSHScan::FingerprintDatabase)
+      expect(File.exist?(file_name)).to eql(true)
+      File.unlink(file_name) #clean up after ourselves
+    end
+
+    it "should use a pre-existing DB if it exists" do
+      file_name = "test.db"
+
+      #start with a known good state
+      File.unlink(file_name) if File.exists?(file_name)
+
+      # Create a pre-existing DB
+      db = ::SQLite3::Database.new(file_name)
+      db.execute <<-SQL
+        create table fingerprints (
+          fingerprint varchar(100),
+          ip varchar(100)
+        );
+      SQL
+      db.execute "insert into fingerprints values ( ?, ? )", ["fake_fingerprint", "127.0.0.1"]
+
+      expect(File.exist?(file_name)).to eql(true)
+      database = SSHScan::FingerprintDatabase.new(file_name)
+      expect(database).to be_kind_of(SSHScan::FingerprintDatabase)
+
+      expect(database.find_fingerprints("fake_fingerprint")).to eql(["127.0.0.1"])
+      File.unlink(file_name) #clean up after ourselves
+    end
+  end
+end

--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('bindata', '~> 2.0')
   s.add_dependency('netaddr')
   s.add_dependency('net-ssh')
+  s.add_dependency('sqlite3')
   s.add_development_dependency('pry')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
Example output modification, when we see an SSH endpoint where the host_key is re-used and the implication becomes that there is a private key dependency with these other hosts....

    "fingerprints": {
      "md5": "1a:8f:af:7d:4d:f7:2e:9d:e7:69:bb:07:17:4c:b0:71",
      "sha1": "b1:0c:5c:58:09:eb:20:3f:10:bc:e1:8b:0e:d8:fd:55:a8:21:60:d4",
      "sha256": "8a:92:84:06:ca:08:64:85:28:a0:36:0f:82:f3:dc:75:01:fc:01:82:35:e8:93:28:9d:e3:aa:b0:33:59:61:16"
    },
    "duplicate_fingerprints": [
      "192.168.10.100"
    ],

This new scan result basically tells us that .99 (the host we scanned) and the .100 host are sharing host_keys, which would be bad in a private key disclosure scenario.