### PR TITLE
Add persistent fingerprint DB capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.db
 /.config
 /coverage/
 /InstalledFiles

--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -18,6 +18,7 @@ options = {
   :threads => 5,
   :verbosity => nil,
   :logger => Logger.new(STDERR),
+  :fingerprint_database => "./fingerprints.db"
 }
 
 target_parser = SSHScan::TargetParser.new()

--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -108,13 +108,18 @@ opt_parser = OptionParser.new do |opts|
     options[:threads] = threads.to_i
   end
 
+  opts.on("--fingerprint-db [FILE]",
+          "File location of fingerprint database (Default: ./fingerprints.db)") do |fingerprint_db|
+    options[:fingerprint_database] = fingerprint_db
+  end
+
   opts.on("-u", "--unit-test [FILE]",
           "Throw appropriate exit codes based on compliance status") do
     options[:unit_test] = true
   end
 
   opts.on("-V", "--verbosity",
-          "Set the logger level (Accpeted Params: INFO, DEBUG, WARN, ERROR, FATAL)") do |verbosity|
+          "Set the logger level (Accepted Params: INFO, DEBUG, WARN, ERROR, FATAL)") do |verbosity|
     options[:logger].level = case options[:verbosity]
       when "INFO" then Logger::INFO
       when "DEBUG" then Logger::DEBUG

--- a/lib/ssh_scan/fingerprint_database.rb
+++ b/lib/ssh_scan/fingerprint_database.rb
@@ -1,0 +1,39 @@
+require 'sqlite3'
+
+module SSHScan
+  class FingerprintDatabase
+    def initialize(database_name)
+      if File.exists?(database_name)
+        @db = ::SQLite3::Database.open(database_name)
+      else
+        @db = ::SQLite3::Database.new(database_name)
+        self.create_schema
+      end
+    end
+
+    def create_schema
+      @db.execute <<-SQL
+        create table fingerprints (
+          fingerprint varchar(100),
+          ip varchar(100)
+        );
+      SQL
+    end
+
+    def clear_fingerprints(ip)
+      @db.execute "delete from fingerprints where ip like ( ? )", [ip]
+    end
+
+    def add_fingerprint(fingerprint, ip)
+      @db.execute "insert into fingerprints values ( ?, ? )", [fingerprint, ip]
+    end
+
+    def find_fingerprints(fingerprint)
+      ips = []
+      @db.execute( "select * from fingerprints where fingerprint like ( ? )", [fingerprint] ) do |row|
+        ips << row[1]
+      end
+      return ips
+    end
+  end
+end

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -136,9 +136,9 @@ module SSHScan
               result['duplicate_host_key_ips'] << other_ip
             end
           end
+          result['duplicate_host_key_ips'].uniq!        
         end
       end
-      result['duplicate_host_key_ips'].uniq! if result['duplicate_host_key_ips']
 
       # Decorate all the results with compliance information
       results.each do |result|

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -138,6 +138,7 @@ module SSHScan
           end
         end
       end
+      result['duplicate_host_key_ips'].uniq! if result['duplicate_host_key_ips']
 
       # Decorate all the results with compliance information
       results.each do |result|

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require 'ssh_scan/client'
 require 'ssh_scan/crypto'
+require 'ssh_scan/fingerprint_database'
 require 'net/ssh'
 
 module SSHScan
@@ -112,6 +113,31 @@ module SSHScan
         end
       end
       workers.map(&:join)
+
+      # Add all the fingerprints to our peristent FingerprintDatabase
+      fingerprint_db = SSHScan::FingerprintDatabase.new(opts[:fingerprint_database])
+      results.each do |result|
+        fingerprint_db.clear_fingerprints(result[:ip])
+        if result['fingerprints']
+          result['fingerprints'].values.each do |fingerprint|
+            fingerprint_db.add_fingerprint(fingerprint, result[:ip])
+          end
+        end
+      end
+
+      # Decorate all the results with duplicate keys
+      results.each do |result|
+        if result['fingerprints']
+          ip = result[:ip]
+          result['duplicate_host_key_ips'] = []
+          result['fingerprints'].values.each do |fingerprint|
+            fingerprint_db.find_fingerprints(fingerprint).each do |other_ip|
+              next if ip == other_ip
+              result['duplicate_host_key_ips'] << other_ip
+            end
+          end
+        end
+      end
 
       # Decorate all the results with compliance information
       results.each do |result|

--- a/spec/ssh_scan/fingerprint_database_spec.rb
+++ b/spec/ssh_scan/fingerprint_database_spec.rb
@@ -1,0 +1,44 @@
+require 'rspec'
+require 'tempfile'
+require 'ssh_scan/fingerprint_database'
+
+describe SSHScan::FingerprintDatabase do
+  context "when initializing a new FingerprintDatabase" do
+    it "should create a new DB on disk if it doesn't exist" do
+      file_name = "test.db"
+
+      #start with a known good state
+      File.unlink(file_name) if File.exists?(file_name)
+
+      expect(File.exist?(file_name)).to eql(false)
+      database = SSHScan::FingerprintDatabase.new(file_name)
+      expect(database).to be_kind_of(SSHScan::FingerprintDatabase)
+      expect(File.exist?(file_name)).to eql(true)
+      File.unlink(file_name) #clean up after ourselves
+    end
+
+    it "should use a pre-existing DB if it exists" do
+      file_name = "test.db"
+
+      #start with a known good state
+      File.unlink(file_name) if File.exists?(file_name)
+
+      # Create a pre-existing DB
+      db = ::SQLite3::Database.new(file_name)
+      db.execute <<-SQL
+        create table fingerprints (
+          fingerprint varchar(100),
+          ip varchar(100)
+        );
+      SQL
+      db.execute "insert into fingerprints values ( ?, ? )", ["fake_fingerprint", "127.0.0.1"]
+
+      expect(File.exist?(file_name)).to eql(true)
+      database = SSHScan::FingerprintDatabase.new(file_name)
+      expect(database).to be_kind_of(SSHScan::FingerprintDatabase)
+
+      expect(database.find_fingerprints("fake_fingerprint")).to eql(["127.0.0.1"])
+      File.unlink(file_name) #clean up after ourselves
+    end
+  end
+end

--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('bindata', '~> 2.0')
   s.add_dependency('netaddr')
   s.add_dependency('net-ssh')
+  s.add_dependency('sqlite3')
   s.add_development_dependency('pry')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
To reproduce this behavior, it requires a little hacking if you don't have an example target...

You're need to scan a host to generate a local fingerprint DB stub

./bin/ssh_scan -t 192.168.10.99

At this time, you shouldn't have any duplicates in your results.  To insert a duplicate into the db you can do this...

sqlite3 fingerprints.db
insert into fingerprints values ('8a:92:84:06:ca:08:64:85:28:a0:36:0f:82:f3:dc:75:01:fc:01:82:35:e8:93:28:9d:e3:aa:b0:33:59:61:16', '192.168.10.100');

Make sure to use a fingerprint string from the original scan.

Once this is added, you can now rescan and get the following host key duplicate decorators...

    "duplicate_host_key_ips": [
      "192.168.10.100"
    ],

This new information added to scans will let us know if we ever come across a host that is sharing keys with another host.  This means we compromise one host, we'll have the private keys to decode traffic from the other.
