### PR TITLE
update enforce logic, shift checks

### DIFF
--- a/spec/ssh_scan/enforce_signed_commits.rb
+++ b/spec/ssh_scan/enforce_signed_commits.rb
@@ -30,7 +30,7 @@ if parts[1] == 'gpg'
       exit 0
     end
   end
-  if keyid.nil?
-    raise "Latest commit #{sha} is not signed!\nCommits must be gpg signed: `git commit -S[<keyid>]`"
-  end
+end
+if keyid.nil?
+  raise "Latest commit #{sha} is not signed!\nCommits must be gpg signed: `git commit -S[<keyid>]`"
 end


### PR DESCRIPTION
For #236.

The Travis CI build should fail since last changes to enforce_signed_commits.rb were unsigned.