### PR TITLE
Added data store for API results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ gh-pages/
 # https ssl certificates
 cert.pem
 key.pem
+
+# API Database
+api.db

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -4,6 +4,7 @@ require 'ssh_scan/version'
 require 'ssh_scan/policy'
 require 'ssh_scan/job_queue'
 require 'ssh_scan/worker'
+require 'ssh_scan/api_db'
 require 'json'
 require 'haml'
 require 'secure_headers'
@@ -97,8 +98,28 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
       end
 
       get '/scan/results' do
-        # TODO: get a given scan result, by UUID and return it as JSON
-        '{"I am not finished yet"}'
+        uuid = params[:uuid]
+
+        if uuid.empty?
+          '{"I am not finished yet"}'
+        end
+
+        settings.db.find_scan_result(uuid)
+      end
+
+      post '/scan/results/delete/:worker_id/:uuid' do
+        uuid = params['uuid']
+        worker_id = params['worker_id']
+
+          if worker_id.empty? || uuid.empty?
+            return {"deleted" => "false"}.to_json
+          end
+
+        settings.db.delete_scan(worker_id, uuid)
+      end
+
+      get '/scan/results/delete/all' do
+        settings.db.delete_all
       end
 
       get '/work' do
@@ -122,9 +143,7 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
           return {"accepted" => "false"}.to_json
         end
 
-        # TODO: add work results to datastore, whatever that ends up being
-
-        return {"accepted" => "true"}.to_json
+        settings.db.find_work_result(worker_id, uuid)
       end
 
       get '/__version__' do
@@ -150,6 +169,7 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
         set :server, "thin"
         set :logger, Logger.new(STDOUT)
         set :job_queue, JobQueue.new()
+        set :db, APIDatabaseHelper.new("api.db")
         set :results, {}
         set :authentication, options["authentication"]
         set :authenticator, SSHScan::Authenticator.from_config_file(

--- a/lib/ssh_scan/api_db.rb
+++ b/lib/ssh_scan/api_db.rb
@@ -1,0 +1,61 @@
+require 'sqlite3'
+
+module SSHScan
+  class APIDatabaseHelper
+    def initialize(database_name)
+      if File.exist?(database_name)
+        @db = ::SQLite3::Database.open(database_name)			
+      else
+        @db = ::SQLite3::Database.new(database_name)
+        self.create_schema
+      end
+    end
+
+    def create_schema
+      @db.execute <<-SQL
+        create table api_schema (
+          worker_id varchar(100),
+          uuid varchar(100),
+          result json
+        );
+      SQL
+    end
+
+    def add_scan(worker_id, uuid, result)
+      @db.execute "insert into api_schema values ( ? , ? , ? )", [worker_id, uuid, result]
+    end
+
+    def delete_scan(worker_id, uuid)
+      @db.execute(
+      	"delete from api_schema where worker_id = ? and uuid = ?",
+      	worker_id, uuid)
+    end
+
+    def delete_all
+    	@db.execute("delete from api_schema")    	
+    end
+
+    def find_scan_result(uuid)
+      scans = []
+      @db.execute(
+        "select * from api_schema where uuid like ( ? )",
+        uuid
+      ) do |row|
+        scans << row[2]
+      end
+      return scans
+    end
+
+    def find_work_result(worker_id, uuid)
+      scans = []
+      @db.execute(
+        "select * from api_schema where uuid =  ? and worker_id = ?",
+        uuid, worker_id
+      ) do |row|
+        scans << row[2]
+      end
+      return scans
+    end    
+
+  end
+end

--- a/lib/ssh_scan/worker.rb
+++ b/lib/ssh_scan/worker.rb
@@ -1,6 +1,7 @@
 require 'ssh_scan/scan_engine'
 require 'openssl'
 require 'net/https'
+require 'ssh_scan/api_db'
 
 module SSHScan
   class Worker
@@ -11,6 +12,7 @@ module SSHScan
       @poll_interval = 5 # seconds
       @worker_id = SecureRandom.uuid
       @verify_ssl = false
+      @api_db = SSHScan::APIDatabaseHelper.new('./api.db')
     end
 
     def self.from_config_file(file_string)
@@ -25,6 +27,7 @@ module SSHScan
           if response["work"]
             job = response["work"]
             results = perform_work(job)
+            @api_db.add_scan(@worker_id, job["uuid"], results.to_json)
             post_results(results, job)
           else
             sleep 0.5


### PR DESCRIPTION
For https://github.com/mozilla/ssh_scan/issues/266 . 

`/api/v1/scan/results?uuid=uuid_string` returns the scan with the specified uuid.
`/api/v1/work/results/worker_id/uuid` returns the scan with specified worker_id and uuid.
`/api/v1/scan/results/delete/worker_id/uuid` deletes the scan with specified worked_id and uuid.
`/api/v1/scan/results/delete/all` deletes all the rows in the table.

@claudijd @pwnbus @gdestuynder review?