### PR TITLE
Switch to nginx for SSL/TLS termination

### DIFF
--- a/bin/ssh_scan_api_example_config.yml
+++ b/bin/ssh_scan_api_example_config.yml
@@ -5,14 +5,9 @@
 # The TCP port that the service should use
 port: 8000
 
-# The locations for they key and crt files for legit SSL/TLS configuration
-#key: the_file_path_to_the_key
-#crt: the_file_path_to_the_crt
-
 # API Tokens (a crude mechanism for adding auth to your API)
 #authentication: true
 authentication: false
-
 
 # If authentication is to true, the authentication tokens you generate below
 # will be required to access certain API functions.

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -178,18 +178,8 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
       end
 
       super do |server|
-        server.ssl = true
-        ssl_opts = {
-        :verify_peer => false,
-        :ssl_version => :TLSv1_2,
-        :ssl_ciphers => "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:\
-          ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:\
-          ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:\
-          ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
-        }
-        ssl_opts[:cert_chain_file] = options["crt"] if options["crt"]
-        ssl_opts[:private_key_file] = options["key"] if options["key"]
-        server.ssl_options = ssl_opts
+        # No SSL on app, SSL termination happens in nginx for a prod deployment
+        server.ssl = false
       end
     end
   end

--- a/nginx/example.conf
+++ b/nginx/example.conf
@@ -1,0 +1,32 @@
+server {
+	listen 443 ssl default_server;
+	listen [::]:443 ssl default_server;
+
+  ssl_certificate /etc/letsencrypt/live/sshscan.rubidus.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/sshscan.rubidus.com/privkey.pem;
+
+  ssl_session_timeout 5m;
+  ssl_session_cache shared:SSL:50m;
+  ssl_session_tickets off;
+
+  ssl_protocols TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+  ssl_prefer_server_ciphers on;
+
+  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
+
+	ssl_stapling on;
+	ssl_stapling_verify on;
+
+  add_header Strict-Transport-Security max-age=15768000;
+
+	server_name sshscan.rubidus.com;
+
+	location / {
+    proxy_pass http://127.0.0.1:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
+
+	resolver 8.8.8.8;
+}

--- a/nginx/example.conf
+++ b/nginx/example.conf
@@ -1,6 +1,6 @@
 server {
-	listen 443 ssl default_server;
-	listen [::]:443 ssl default_server;
+  listen 443 ssl default_server;
+  listen [::]:443 ssl default_server;
 
   ssl_certificate /etc/letsencrypt/live/sshscan.rubidus.com/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/sshscan.rubidus.com/privkey.pem;
@@ -15,18 +15,18 @@ server {
 
   ssl_dhparam /etc/nginx/ssl/dhparam.pem;
 
-	ssl_stapling on;
-	ssl_stapling_verify on;
+  ssl_stapling on;
+  ssl_stapling_verify on;
 
   add_header Strict-Transport-Security max-age=15768000;
 
-	server_name sshscan.rubidus.com;
-
-	location / {
+  server_name sshscan.rubidus.com;
+ 
+  location / {
     proxy_pass http://127.0.0.1:8000;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
   }
 
-	resolver 8.8.8.8;
+  resolver 8.8.8.8;
 }


### PR DESCRIPTION
SSL termination on webrick/thin was proving to be annoying, so I switched the deployment model over nginx so developers don't even need to worry about it and provided an example of the nginx config in git so it's transparent how it's all setup.