### PR TITLE
Fix up worker to allow HTTP/HTTPS options

### DIFF
--- a/bin/ssh_scan_worker_example_config.yml
+++ b/bin/ssh_scan_worker_example_config.yml
@@ -1,5 +1,13 @@
-# The location of the API server
-server: 127.0.0.1
+# The location of the API server URL
+server_url: 127.0.0.1
 
 # The port of the API server
 port: 8000
+
+# Scheme (http/https)
+scheme: http
+
+# SSL/TLS verify
+# false - don't verify SSL/TLS (useful for development)
+# true - verify SSL/TLS (recommended for production)
+verify: false

--- a/bin/ssh_scan_worker_example_config.yml
+++ b/bin/ssh_scan_worker_example_config.yml
@@ -1,5 +1,5 @@
 # The location of the API server URL
-server_url: 127.0.0.1
+server: 127.0.0.1
 
 # The port of the API server
 port: 8000

--- a/bin/ssh_scan_worker_example_config.yml
+++ b/bin/ssh_scan_worker_example_config.yml
@@ -1,13 +1,15 @@
-# The location of the API server URL
+# The location of the API server
 server: 127.0.0.1
 
 # The port of the API server
 port: 8000
 
 # Scheme (http/https)
+# http - useful for development
+# https - recommended for production
 scheme: http
 
-# SSL/TLS verify
+# SSL/TLS verify - has no effect is scheme is not set to https
 # false - don't verify SSL/TLS (useful for development)
 # true - verify SSL/TLS (recommended for production)
 verify: false


### PR DESCRIPTION
Make the worker a little more flexible to allow HTTP/HTTPS comms, this sets the default to HTTP to be helpful to develop but allows you some tunables you might want as you work toward a production setup.