### PR TITLE
Add ssh_scan_api_client example

### DIFF
--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -167,7 +167,8 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
       configure do
         set :bind, options["bind"] || '127.0.0.1'
         set :server, "thin"
-        set :logger, Logger.new(STDOUT)
+        enable :logging
+        #set :logger, Logger.new(STDOUT)
         set :job_queue, JobQueue.new()
         set :db, APIDatabaseHelper.new("api.db")
         set :results, {}


### PR DESCRIPTION
A ruby example of an ssh_scan_api_client.  I suppose at some point, we may want to provide a variety of different programming language examples for people to play around with.