### PR TITLE
API caching feature

### DIFF
--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -149,7 +149,8 @@ scan") do |file|
     options["unit_test"] = true
   end
 
-  opts.on("-V", "--verbosity [STD_LOGGING_LEVEL]", "File to write JSON output to") do |verb|
+  opts.on("-V", "--verbosity [STD_LOGGING_LEVEL]",
+          "File to write JSON output to") do |verb|
     case verb
     when "INFO"
       options["logger"].level ==  Logger::INFO
@@ -157,8 +158,6 @@ scan") do |file|
       options["logger"].level ==  Logger::WARN
     when "DEBUG"
       options["logger"].level ==  Logger::DEBUG
-    when "WARN"
-      options["logger"].level ==  Logger::WARN
     when "ERROR"
       options["logger"].level ==  Logger::ERROR
     when "FATAL"

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -166,13 +166,15 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
         uuid = params['uuid']
         result = JSON.parse(request.body.first).first
         socket = {}
-        socket[:ip] = result['ip']
+        socket[:target] = result['ip']
         socket[:port] = result['port']
 
         if worker_id.empty? || uuid.empty?
           return {"accepted" => "false"}.to_json
         end
 
+        available_result = settings.db.fetch_available_result(socket)
+        settings.db.delete_scan(available_result) unless available_result.nil?
         settings.db.add_scan(worker_id, uuid, result, socket)
       end
 

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -103,6 +103,11 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
         options[:sockets] <<
           "#{params[:target]}:#{params[:port] ? params[:port] : "22"}"
         options[:policy_file] = options[:policy]
+        options[:force] = params[:force] ? params[:force] : false
+        unless (options[:force] == 'true')
+          available_result = settings.db.fetch_available_result(params)
+          return { uuid: available_result }.to_json unless available_result.nil?
+        end
         options[:uuid] = SecureRandom.uuid
         settings.job_queue.add(options)
         {
@@ -158,12 +163,16 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
       post '/work/results/:worker_id/:uuid' do
         worker_id = params['worker_id']
         uuid = params['uuid']
+        result = JSON.parse(request.body.first).first
+        socket = {}
+        socket[:ip] = result['ip']
+        socket[:port] = result['port']
 
         if worker_id.empty? || uuid.empty?
           return {"accepted" => "false"}.to_json
         end
 
-        settings.db.add_scan(worker_id, uuid, JSON.parse(request.body.first).first)
+        settings.db.add_scan(worker_id, uuid, result, socket)
       end
 
       get '/__lbheartbeat__' do

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -18,7 +18,7 @@ module SSHScan
       configure do
         set :job_queue, JobQueue.new()
         set :authentication, false
-        set :db, SSHScan::DatabaseConfig.from_config_file
+        set :db, SSHScan::Database.from_hash(options)
       end
     end
 

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -18,6 +18,7 @@ module SSHScan
       configure do
         set :job_queue, JobQueue.new()
         set :authentication, false
+        set :db, SSHScan::DatabaseConfig.from_config_file
       end
     end
 

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -18,10 +18,7 @@ module SSHScan
       configure do
         set :job_queue, JobQueue.new()
         set :authentication, false
-        config_file = File.join(
-                File.expand_path(Dir.pwd),
-                "/config/api/config.yml"
-              )
+        config_file = File.join(Dir.pwd, "/config/api/config.yml")
         opts = YAML.load_file(config_file)
         opts["config_file"] = config_file
         set :db, SSHScan::Database.from_hash(opts)

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -105,10 +105,12 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
           "#{params[:target]}:#{params[:port] ? params[:port] : "22"}"
         options[:policy_file] = options[:policy]
         options[:force] = params[:force] ? params[:force] : false
-        unless (options[:force] == 'true')
+        unless options[:force] == 'true'
           available_result = settings.db.fetch_available_result(params)
           unless available_result.nil?
-            if ((Time.now - Time.parse(available_result[:scanned_on].to_s))/(60*60*24) < 1)
+            if (Time.now -
+                Time.parse(available_result[:scanned_on].to_s)
+               ) / (60 * 60 * 24) < 1
               return {
                 uuid: available_result[:uuid],
                 scanned_on: available_result[:scanned_on]
@@ -183,7 +185,8 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
 
         available_result = settings.db.fetch_available_result(socket)
         unless available_result.nil?
-          settings.db.delete_scan(available_result[:uuid]) unless available_result[:uuid] == params['uuid']
+          settings.db.delete_scan(available_result[:uuid]) unless
+            available_result[:uuid] == params['uuid']
         end
         settings.db.add_scan(worker_id, uuid, result, socket)
       end

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -18,7 +18,13 @@ module SSHScan
       configure do
         set :job_queue, JobQueue.new()
         set :authentication, false
-        set :db, SSHScan::Database.from_hash(options)
+        config_file = File.join(
+                File.expand_path(Dir.pwd),
+                "/config/api/config.yml"
+              )
+        opts = YAML.load_file(config_file)
+        opts["config_file"] = config_file
+        set :db, SSHScan::Database.from_hash(opts)
       end
     end
 
@@ -122,7 +128,7 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
         settings.job_queue.add(options)
         {
           uuid: options[:uuid],
-          scanned_on: 'fresh scan'
+          scanned_on: Time.now
         }.to_json
       end
 

--- a/lib/ssh_scan/api.rb
+++ b/lib/ssh_scan/api.rb
@@ -107,11 +107,13 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
         options[:force] = params[:force] ? params[:force] : false
         unless (options[:force] == 'true')
           available_result = settings.db.fetch_available_result(params)
-          unless available_result.nil? || ((Time.now - available_result[:scanned_on])/(60*60*24) > 1)
-            return {
-              uuid: available_result[:uuid],
-              scanned_on: available_result[:scanned_on].localtime
-            }.to_json
+          unless available_result.nil?
+            if ((Time.now - Time.parse(available_result[:scanned_on].to_s))/(60*60*24) < 1)
+              return {
+                uuid: available_result[:uuid],
+                scanned_on: available_result[:scanned_on]
+              }.to_json
+            end
           end
         end
         options[:uuid] = SecureRandom.uuid
@@ -180,7 +182,9 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
         end
 
         available_result = settings.db.fetch_available_result(socket)
-        settings.db.delete_scan(available_result[:uuid]) unless available_result.nil?
+        unless available_result.nil?
+          settings.db.delete_scan(available_result[:uuid]) unless available_result[:uuid] == params['uuid']
+        end
         settings.db.add_scan(worker_id, uuid, result, socket)
       end
 

--- a/lib/ssh_scan/database.rb
+++ b/lib/ssh_scan/database.rb
@@ -54,8 +54,8 @@ module SSHScan
     end
 
     # @return [Hash] result
-    def fetch_available_result(socket)
-      @database.fetch_available_result(socket)
+    def fetch_cached_result(socket)
+      @database.fetch_cached_result(socket)
     end
   end
 end

--- a/lib/ssh_scan/database.rb
+++ b/lib/ssh_scan/database.rb
@@ -32,8 +32,8 @@ module SSHScan
     # @param [String] uuid
     # @param [Hash] result
     # @return [Nil]
-    def add_scan(worker_id, uuid, result)
-      @database.add_scan(worker_id, uuid, result)
+    def add_scan(worker_id, uuid, result, socket)
+      @database.add_scan(worker_id, uuid, result, socket)
       return nil
     end
 
@@ -51,6 +51,11 @@ module SSHScan
     # @return [Hash] result
     def find_scan_result(uuid)
       @database.find_scan_result(uuid)
+    end
+
+    # @return [Hash] result
+    def fetch_available_result(socket)
+      @database.fetch_available_result(socket)
     end
   end
 end

--- a/lib/ssh_scan/database/mongo.rb
+++ b/lib/ssh_scan/database/mongo.rb
@@ -47,6 +47,14 @@ module SSHScan
         
         return nil
       end
+
+      def fetch_available_result(socket)
+        results = @scans.find(:target => socket[:target], :port => socket[:port])
+        return nil if results.count.zero?
+        results.each do |doc|
+          return doc[:uuid]
+        end
+      end
     end
   end
 end

--- a/lib/ssh_scan/database/mongo.rb
+++ b/lib/ssh_scan/database/mongo.rb
@@ -51,8 +51,11 @@ module SSHScan
       def fetch_available_result(socket)
         results = @scans.find(:target => socket[:target], :port => socket[:port])
         return nil if results.count.zero?
+        result = {}
         results.each do |doc|
-          return doc[:uuid]
+          result[:scanned_on] = doc[:scanned_on]
+          result[:uuid] = doc[:uuid]
+          return result
         end
       end
     end

--- a/lib/ssh_scan/database/mongo.rb
+++ b/lib/ssh_scan/database/mongo.rb
@@ -26,9 +26,13 @@ module SSHScan
       # @param [String] worker_id
       # @param [String] uuid
       # @param [Hash] result
-      def add_scan(worker_id, uuid, result)
-        @collection.insert_one("uuid" => uuid, "scan" => result,
-                          "worker_id" => worker_id, "scanned_on" => Time.now)
+       def add_scan(worker_id, uuid, result, socket)
+        @collection.insert_one("uuid" => uuid,
+                          "target" => socket[:target],
+                          "port" => socket[:port],
+                          "scan" => result,
+                          "worker_id" => worker_id,
+                          "scanned_on" => Time.now)
       end
 
       def delete_scan(uuid)
@@ -49,7 +53,7 @@ module SSHScan
       end
 
       def fetch_available_result(socket)
-        results = @scans.find(:target => socket[:target], :port => socket[:port])
+        results = @collection.find(:target => socket[:target], :port => socket[:port])
         return nil if results.count.zero?
         result = {}
         results.each do |doc|

--- a/lib/ssh_scan/database/mongo.rb
+++ b/lib/ssh_scan/database/mongo.rb
@@ -31,8 +31,7 @@ module SSHScan
                           "target" => socket[:target],
                           "port" => socket[:port],
                           "scan" => result,
-                          "worker_id" => worker_id,
-                          "scanned_on" => Time.now)
+                          "worker_id" => worker_id)
       end
 
       def delete_scan(uuid)
@@ -52,13 +51,14 @@ module SSHScan
         return nil
       end
 
-      def fetch_available_result(socket)
+      def fetch_cached_result(socket)
         results = @collection.find(:target => socket[:target], :port => socket[:port])
+        results = results.skip(results.count() - 1)
         return nil if results.count.zero?
         result = {}
-        results.each do |doc|
-          result[:scanned_on] = doc[:scanned_on]
-          result[:uuid] = doc[:uuid]
+        results.each do |result|
+          result[:uuid] = result[:uuid]
+          result[:start_time] = result[:scan][:start_time]
           return result
         end
       end

--- a/lib/ssh_scan/database/sqlite.rb
+++ b/lib/ssh_scan/database/sqlite.rb
@@ -34,8 +34,7 @@ module SSHScan
               target varchar(100),
               port varchar(100),
               result json,
-              worker_id varchar(100),
-              scanned_on datetime
+              worker_id varchar(100)
             );
           SQL
         end
@@ -49,9 +48,9 @@ module SSHScan
       end
 
       def add_scan(worker_id, uuid, result, socket)
-        @database.execute "insert into ssh_scan values ( ? , ? , ? , ? , ? , ? )",
+        @database.execute "insert into ssh_scan values ( ? , ? , ? , ? , ? )",
                     [uuid, socket[:target], socket[:port],
-                     result.to_json, worker_id, Time.now.to_s]
+                     result.to_json, worker_id]
       end
 
       def delete_scan(uuid)
@@ -75,16 +74,16 @@ module SSHScan
         return nil
       end
 
-      def fetch_available_result(socket)
+      def fetch_cached_result(socket)
         result = {}
         results = @database.execute(
-          "select uuid, scanned_on from ssh_scan
+          "select uuid, result from ssh_scan
           where target like ( ? ) and port like ( ? )",
           [socket[:target], socket[:port]]
         )
         return nil if results == []
-        result[:uuid] = results[0][0]
-        result[:scanned_on] = results[0][1]
+        result[:uuid] = results[result.length()-1][0]
+        result[:start_time] = JSON.parse(results[result.length()-1][1])["start_time"]
         return result
       end
     end

--- a/lib/ssh_scan/database/sqlite.rb
+++ b/lib/ssh_scan/database/sqlite.rb
@@ -75,7 +75,8 @@ module SSHScan
       def fetch_available_result(socket)
         result = {}
         results = @db.execute(
-          "select uuid, scanned_on from api_schema where target like ( ? ) and port like ( ? )",
+          "select uuid, scanned_on from api_schema
+          where target like ( ? ) and port like ( ? )",
           [socket[:target], socket[:port]]
         )
         return nil if results == []

--- a/lib/ssh_scan/database/sqlite.rb
+++ b/lib/ssh_scan/database/sqlite.rb
@@ -71,6 +71,17 @@ module SSHScan
         end
         return nil
       end
+
+      def fetch_available_result(socket)
+        uuid = []
+        @db.execute(
+          "select uuid from api_schema where target like ( ? ) and port like ( ? )",
+          [socket[:target], socket[:port]]
+        ) do |row|
+          uuid << row[3]
+        end
+        return uuid
+      end
     end
   end
 end

--- a/lib/ssh_scan/database/sqlite.rb
+++ b/lib/ssh_scan/database/sqlite.rb
@@ -73,14 +73,15 @@ module SSHScan
       end
 
       def fetch_available_result(socket)
-        uuid = []
-        @db.execute(
-          "select uuid from api_schema where target like ( ? ) and port like ( ? )",
+        result = {}
+        results = @db.execute(
+          "select uuid, scanned_on from api_schema where target like ( ? ) and port like ( ? )",
           [socket[:target], socket[:port]]
-        ) do |row|
-          uuid << row[3]
-        end
-        return uuid
+        )
+        return nil if results == []
+        result[:uuid] = results[0][0]
+        result[:scanned_on] = results[0][1]
+        return result
       end
     end
   end

--- a/spec/ssh_scan/api_spec.rb
+++ b/spec/ssh_scan/api_spec.rb
@@ -64,10 +64,10 @@ https://github.com/mozilla/ssh_scan/wiki/ssh_scan-Web-API\n"
     }.to_json)
   end
 
-  it "should say ConnectTimeout for bad IP, and return valid JSON" do
-    bad_ip = "192.168.255.255"
-    port = "999"
-    post "/api/v#{SSHScan::API_VERSION}/scan", {:target => bad_ip, :port => port}
+  it "should return string uuid" do
+    ip = "192.168.1.1"
+    port = "22"
+    post "/api/v#{SSHScan::API_VERSION}/scan", {:target => ip, :port => port}
     expect(last_response.status).to eql(200)
     expect(last_response.body).to be_kind_of(::String)
     expect(last_response["Content-Type"]).to eql("application/json") 

--- a/spec/ssh_scan/database/mongodb_spec.rb
+++ b/spec/ssh_scan/database/mongodb_spec.rb
@@ -36,9 +36,6 @@ describe SSHScan::DB::MongoDb do
     expect(doc["uuid"]).to eql(uuid)
     expect(doc["scan"]).to eql(result)
     expect(doc["worker_id"]).to eql(worker_id)
-
-    #Example: "2017-01-05 14:08:08 -0500"
-    expect(doc["scanned_on"].to_s).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/)
   end
 
   it "should #delete_scan only the scan we ask it to" do

--- a/spec/ssh_scan/database/mongodb_spec.rb
+++ b/spec/ssh_scan/database/mongodb_spec.rb
@@ -23,10 +23,11 @@ describe SSHScan::DB::MongoDb do
     worker_id = SecureRandom.uuid
     uuid = SecureRandom.uuid
     result = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
     temp_file = Tempfile.new('sqlite_database_file')
 
-    @mongodb.add_scan(worker_id, uuid, result)
+    @mongodb.add_scan(worker_id, uuid, result, socket)
 
     # Emulate the retrieval process
     doc = @mongodb.collection.find(:uuid => uuid).first
@@ -45,9 +46,10 @@ describe SSHScan::DB::MongoDb do
     uuid1 = SecureRandom.uuid
     uuid2 = SecureRandom.uuid
     result = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
-    @mongodb.add_scan(worker_id, uuid1, result)
-    @mongodb.add_scan(worker_id, uuid2, result)
+    @mongodb.add_scan(worker_id, uuid1, result, socket)
+    @mongodb.add_scan(worker_id, uuid2, result, socket)
 
     # Verify that we now have two entries in the DB
     first_docs = @mongodb.collection.find(:worker_id => worker_id)
@@ -67,9 +69,10 @@ describe SSHScan::DB::MongoDb do
     uuid1 = SecureRandom.uuid
     uuid2 = SecureRandom.uuid
     result = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
-    @mongodb.add_scan(worker_id, uuid1, result)
-    @mongodb.add_scan(worker_id, uuid2, result)
+    @mongodb.add_scan(worker_id, uuid1, result, socket)
+    @mongodb.add_scan(worker_id, uuid2, result, socket)
 
     # Let's delete all of them via the collection
     @mongodb.delete_all
@@ -85,9 +88,10 @@ describe SSHScan::DB::MongoDb do
     uuid2 = SecureRandom.uuid
     result1 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
     result2 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar2", "biz" => "baz2"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
-    @mongodb.add_scan(worker_id, uuid1, result1)
-    @mongodb.add_scan(worker_id, uuid2, result2)
+    @mongodb.add_scan(worker_id, uuid1, result1, socket)
+    @mongodb.add_scan(worker_id, uuid2, result2, socket)
 
     # It should find the first scan
     response1 = @mongodb.find_scan_result(uuid1)
@@ -105,8 +109,9 @@ describe SSHScan::DB::MongoDb do
     uuid1 = SecureRandom.uuid
     bogus_uuid = SecureRandom.uuid
     result1 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
-    @mongodb.add_scan(worker_id, uuid1, result1)
+    @mongodb.add_scan(worker_id, uuid1, result1, socket)
 
     # It should return nil for a non-existant uuid
     response = @mongodb.find_scan_result(bogus_uuid)

--- a/spec/ssh_scan/database/sqlite_spec.rb
+++ b/spec/ssh_scan/database/sqlite_spec.rb
@@ -41,14 +41,10 @@ describe SSHScan::DB::SQLite do
     #   "{\"ip\":\"127.0.0.1\",\"port\":1337,\"foo\":\"bar\",\"biz\":\"baz\"}",
     #   "116f5b0b-a768-44f4-a663-31237710139c",
     #   "2017-01-11 16:21:01 -0500"]]
-    puts response.inspect
     expect(response.size).to eql(1)
     expect(response.first[0]).to eql(uuid)
     expect(response.first[3]).to eql(result.to_json)
     expect(response.first[4]).to eql(worker_id)
-
-    #Example: "2017-01-05 14:08:08 -0500"
-    expect(response.first[5]).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-\+]\d{4}/)
 
     temp_file.close
   end

--- a/spec/ssh_scan/database/sqlite_spec.rb
+++ b/spec/ssh_scan/database/sqlite_spec.rb
@@ -23,6 +23,7 @@ describe SSHScan::DB::SQLite do
     worker_id = SecureRandom.uuid
     uuid = SecureRandom.uuid
     result = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
     temp_file = Tempfile.new('sqlite_database_file')
 
@@ -31,7 +32,7 @@ describe SSHScan::DB::SQLite do
     }
 
     sqlite_db = SSHScan::DB::SQLite.from_hash(opts)
-    sqlite_db.add_scan(worker_id, uuid, result)
+    sqlite_db.add_scan(worker_id, uuid, result, socket)
 
     response = sqlite_db.database.execute("select * from ssh_scan where uuid like ( ? )", uuid)
 
@@ -40,13 +41,14 @@ describe SSHScan::DB::SQLite do
     #   "{\"ip\":\"127.0.0.1\",\"port\":1337,\"foo\":\"bar\",\"biz\":\"baz\"}",
     #   "116f5b0b-a768-44f4-a663-31237710139c",
     #   "2017-01-11 16:21:01 -0500"]]
+    puts response.inspect
     expect(response.size).to eql(1)
     expect(response.first[0]).to eql(uuid)
-    expect(response.first[1]).to eql(result.to_json)
-    expect(response.first[2]).to eql(worker_id)
+    expect(response.first[3]).to eql(result.to_json)
+    expect(response.first[4]).to eql(worker_id)
 
     #Example: "2017-01-05 14:08:08 -0500"
-    expect(response.first[3]).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-\+]\d{4}/)
+    expect(response.first[5]).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-\+]\d{4}/)
 
     temp_file.close
   end
@@ -56,6 +58,7 @@ describe SSHScan::DB::SQLite do
     uuid1 = SecureRandom.uuid
     uuid2 = SecureRandom.uuid
     result = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
     temp_file = Tempfile.new('sqlite_database_file')
 
@@ -64,8 +67,8 @@ describe SSHScan::DB::SQLite do
     }
 
     sqlite_db = SSHScan::DB::SQLite.from_hash(opts)
-    sqlite_db.add_scan(worker_id, uuid1, result)
-    sqlite_db.add_scan(worker_id, uuid2, result)
+    sqlite_db.add_scan(worker_id, uuid1, result, socket)
+    sqlite_db.add_scan(worker_id, uuid2, result, socket)
 
     # Verify that we now have two entries in the DB
     response1 = sqlite_db.database.execute("select * from ssh_scan where worker_id like ( ? )", worker_id)
@@ -76,8 +79,8 @@ describe SSHScan::DB::SQLite do
     response2 = sqlite_db.database.execute("select * from ssh_scan where worker_id like ( ? )", worker_id)
     expect(response2.size).to eql(1)
     expect(response2.first[0]).to eql(uuid2)
-    expect(response2.first[1]).to eql(result.to_json)
-    expect(response2.first[2]).to eql(worker_id)
+    expect(response2.first[3]).to eql(result.to_json)
+    expect(response2.first[4]).to eql(worker_id)
 
     temp_file.close
   end
@@ -87,6 +90,7 @@ describe SSHScan::DB::SQLite do
     uuid1 = SecureRandom.uuid
     uuid2 = SecureRandom.uuid
     result = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
     temp_file = Tempfile.new('sqlite_database_file')
 
@@ -95,8 +99,8 @@ describe SSHScan::DB::SQLite do
     }
 
     sqlite_db = SSHScan::DB::SQLite.from_hash(opts)
-    sqlite_db.add_scan(worker_id, uuid1, result)
-    sqlite_db.add_scan(worker_id, uuid2, result)
+    sqlite_db.add_scan(worker_id, uuid1, result, socket)
+    sqlite_db.add_scan(worker_id, uuid2, result, socket)
 
     # Verify that we now have two entries in the DB
     response1 = sqlite_db.database.execute("select * from ssh_scan where worker_id like ( ? )", worker_id)
@@ -116,6 +120,7 @@ describe SSHScan::DB::SQLite do
     uuid2 = SecureRandom.uuid
     result1 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
     result2 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar2", "biz" => "baz2"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
 
     temp_file = Tempfile.new('sqlite_database_file')
@@ -125,8 +130,8 @@ describe SSHScan::DB::SQLite do
     }
 
     sqlite_db = SSHScan::DB::SQLite.from_hash(opts)
-    sqlite_db.add_scan(worker_id, uuid1, result1)
-    sqlite_db.add_scan(worker_id, uuid2, result2)
+    sqlite_db.add_scan(worker_id, uuid1, result1, socket)
+    sqlite_db.add_scan(worker_id, uuid2, result2, socket)
 
     # It should find the first scan
     response1 = sqlite_db.find_scan_result(uuid1)
@@ -146,6 +151,7 @@ describe SSHScan::DB::SQLite do
     uuid1 = SecureRandom.uuid
     bogus_uuid = SecureRandom.uuid
     result1 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz"}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
 
     temp_file = Tempfile.new('sqlite_database_file')
 
@@ -154,7 +160,7 @@ describe SSHScan::DB::SQLite do
     }
 
     sqlite_db = SSHScan::DB::SQLite.from_hash(opts)
-    sqlite_db.add_scan(worker_id, uuid1, result1)
+    sqlite_db.add_scan(worker_id, uuid1, result1, socket)
 
     # It should return nil for a non-existant uuid
     response = sqlite_db.find_scan_result(bogus_uuid)

--- a/spec/ssh_scan/database_spec.rb
+++ b/spec/ssh_scan/database_spec.rb
@@ -22,9 +22,10 @@ describe SSHScan::Database do
     worker_id = SecureRandom.uuid
     uuid = SecureRandom.uuid
     result = {:ip => "127.0.0.1", :port => 1337, :foo => "bar", :biz => "baz"}
+    socket = {:target => "127.0.0.1", :port => 1337}
 
-    expect(@test_database).to receive(:add_scan).with(worker_id, uuid, result)
-    @abstract_database.add_scan(worker_id, uuid, result)
+    expect(@test_database).to receive(:add_scan).with(worker_id, uuid, result, socket)
+    @abstract_database.add_scan(worker_id, uuid, result, socket)
   end
 
   it "should defer #delete_scan calls to the specific DB implementation" do


### PR DESCRIPTION
Provides a caching feature in the API retrieving pre-existing scan results when present.

I am still working on it but opening this PR so that everyone can see where it is headed and suggest improvements.

This PR is separate from but is based on changes from PR #291, so it contains changes from earlier PR mixed with this too.
This addresses Issue #296.