### PR TITLE
add configuration loader + example

### DIFF
--- a/config/loader_configs/policy.yml
+++ b/config/loader_configs/policy.yml
@@ -1,0 +1,11 @@
+allowed:
+  - rules
+  - ruleset
+  - name
+  - ssh_version
+  - auth_methods
+  - kex
+  - encryption
+  - macs
+  - compression
+  - references

--- a/lib/ssh_scan.rb
+++ b/lib/ssh_scan.rb
@@ -15,6 +15,7 @@ require 'ssh_scan/update'
 require 'ssh_scan/job_queue'
 require 'ssh_scan/worker'
 require 'ssh_scan/api'
+require 'ssh_scan/config_loader'
 
 #Monkey Patches
 require 'string_ext'

--- a/lib/ssh_scan/authenticator.rb
+++ b/lib/ssh_scan/authenticator.rb
@@ -7,7 +7,7 @@ module SSHScan
     end
 
     def self.from_config_file(config_file)
-      opts = YAML.load_file(config_file)
+      opts = SSHScan::ConfigLoader.load(config_file, self)
       SSHScan::Authenticator.new(opts)
     end
 

--- a/lib/ssh_scan/config_loader.rb
+++ b/lib/ssh_scan/config_loader.rb
@@ -1,0 +1,37 @@
+require 'logger'
+
+require 'ssh_scan/config_loader/yaml'
+
+module SSHScan
+  module ConfigLoader
+    def self.load(config, class_name = nil, logger = nil)
+      ext = File.extname(config) if config
+      case config
+      when File
+        if ext == ".yml"
+          loaded_config = SSHScan::ConfigLoader::Yaml.new(config, class_name, 'file', logger)
+        else
+          raise "no support for this kind of file yet: #{ext}"
+        end
+      when String
+        # Change for other formats when they are available?
+        if config.include?(".yml") && File.exist?(config)
+          if ext == ".yml"
+            loaded_config = SSHScan::ConfigLoader::Yaml.new(config, class_name, 'file', logger)
+          else
+            raise "no support for this kind of file yet: #{ext}"
+          end
+        else
+          if !!YAML.load(config)
+            loaded_config = SSHScan::ConfigLoader::Yaml.new(config, class_name, 'string', logger)
+          else
+            raise "unknown syntax"
+          end
+        end
+      else
+        raise "unsupported config object type #{config.class}"
+      end
+      return loaded_config.checkedOpts
+    end
+  end
+end

--- a/lib/ssh_scan/config_loader/yaml.rb
+++ b/lib/ssh_scan/config_loader/yaml.rb
@@ -1,0 +1,72 @@
+require 'yaml'
+
+module SSHScan
+  module ConfigLoader
+    class Yaml
+      def initialize(config, class_name = nil, mode = 'file', logger = nil)
+        @opts = case mode
+          when "file" then YAML.load_file(config)
+          when "string" then YAML.load(config)
+        end
+        @logger = logger || Logger.new(STDOUT)
+        @class_name = class_name ? class_name.name : ""
+        @good_opts = loadGoodOpts
+      end
+
+      def opts
+        @opts
+      end
+
+      def checkedOpts
+        unless @good_opts.nil?
+          allowed = @good_opts["allowed"]
+          error_count = 0
+          retrieved_opts = opts
+          retrieved_opts.each do |key, value|
+            unless allowed.include?(key)
+              @logger.error("attribute not allowed: #{key}")
+              error_count += 1
+            end
+          end
+          @logger.fatal("error count for #{@class_name} configuration: #{error_count}") if error_count > 0
+        end
+        @opts
+      end
+
+      def loadGoodOpts
+
+        # This function loads the appropriate yml file that lists the attributes allowed
+        # for a configuration file associated with a class. For example, suppose policy
+        # configuration files (SSHScan::Policy) can only have attributes a, b, c then
+        # we can have a whitelist at config/loader_configs
+        ###########
+        # allowed:
+        # - a
+        # - b
+        # - c
+        ###########
+        # Our requirement is one such whitelist per class, so a good way to name such files
+        # is just downcasing their classnames. Examples of class - whitelist filenames:
+        # SSHScan::Authenticator => config/loader_configs/authenticator.yml
+        # SSHScan::Policy        => config/loader_configs/policy.yml
+        # SSHScan::A::B::C       => config/loader_configs/a_b_c.yml
+        # and so on ... (SSHScan:: is redundant in these classnames, so let's not have it)
+
+        unless @class_name.nil?
+          configs_dir = File.join(File.dirname(__FILE__), "../../../config/loader_configs")
+          reduced_class_name = @class_name.downcase.split("::").join("_")
+          # 'sshscan_' in every class name is redundant
+          reduced_class_name.gsub!("sshscan_", "")
+          possible_file = File.expand_path(File.join(configs_dir, "#{reduced_class_name}.yml"))
+          begin
+            config = YAML.load_file(possible_file)
+          rescue Errno::ENOENT
+            @logger.error("File #{possible_file} does not exist.")
+          else
+            return config
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ssh_scan/policy.rb
+++ b/lib/ssh_scan/policy.rb
@@ -1,4 +1,4 @@
-require 'yaml'
+require 'ssh_scan/config_loader'
 
 module SSHScan
   class Policy
@@ -17,12 +17,12 @@ module SSHScan
     end
 
     def self.from_file(file)
-      opts = YAML.load_file(file)
+      opts = SSHScan::ConfigLoader.load(file, self)
       self.new(opts)
     end
 
     def self.from_string(string)
-      opts = YAML.load(string)
+      opts = SSHScan::ConfigLoader.load(string, self)
       self.new(opts)
     end
   end

--- a/lib/ssh_scan/worker.rb
+++ b/lib/ssh_scan/worker.rb
@@ -27,7 +27,7 @@ module SSHScan
     end
 
     def self.from_config_file(file_string)
-      opts = YAML.load_file(file_string)
+      opts = SSHScan::ConfigLoader.load(file_string, self, @logger)
       SSHScan::Worker.new(opts)
     end
 

--- a/spec/ssh_scan/policy_spec.rb
+++ b/spec/ssh_scan/policy_spec.rb
@@ -40,7 +40,7 @@ encryption:\n- aes256-ctr\n- aes192-ctr\n\
 references:\n- https://wiki.mozilla.org/Security/Guidelines/OpenSSH\n"
 
     it "should load all the attributes properly" do
-      file = Tempfile.new('foo')
+      file = Tempfile.new(['foo', '.yml']) # enforcing extension
       file.write(yaml_string)
       file.close
 


### PR DESCRIPTION
This is the idea I had for a generic configuration loader (#306). Let's discuss this and I'll add unit tests after this looks more mature.

Things I can improve
1. This doesn't allow nested whitelists. So if attribute A can have sub attribute B, there is no check for that. Only one level of whitelisting allowed.
2. I can condense the large number of attributes for the function to be taken as `opts` argument.
3. I still have no idea how to judge whether the syntax is YAML or JSON or XML for a given config string. Maybe I can do that better.

(Unit tests failing because one unit test relies on creating a tmpfile with no extension)

Thanks!