### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Examples:
 
 - See here for [example video](https://asciinema.org/a/7pliiw5zqhj7eqvz7q437u6vx)
 - See here for [example output](https://github.com/mozilla/ssh_scan/blob/master/examples/192.168.1.1.json)
-- See here for [example policies](https://github.com/mozilla/ssh_scan/blob/master/policies)
+- See here for [example policies](https://github.com/mozilla/ssh_scan/blob/master/config/policies)
 
 ## Rubies Supported
 


### PR DESCRIPTION
Corrected link to example polices to point to config/policies. No code change, just found that the link to the polices is now under `config` not just in the root. Wanted to updated the README.

- What did I do?
Clicked on link to example policies.
- What did I expect to happen?
To be taken to the example policies
- What happened instead?
I was taken to a Github 404