### PR TITLE
Add ssh-badkey detection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data/ssh-badkeys"]
+	path = data/ssh-badkeys
+	url = git@github.com:rapid7/ssh-badkeys.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data/ssh-badkeys"]
 	path = data/ssh-badkeys
-	url = git@github.com:rapid7/ssh-badkeys.git
+	url = https://github.com:rapid7/ssh-badkeys.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data/ssh-badkeys"]
 	path = data/ssh-badkeys
-	url = https://github.com:rapid7/ssh-badkeys.git
+	url = git@github.com:rapid7/ssh-badkeys.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+git:
+  submodules: false
+before_install:
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
 matrix:
   include:
   - rvm: ruby-head

--- a/examples/github.com.json
+++ b/examples/github.com.json
@@ -1,7 +1,7 @@
 [
   {
-    "ssh_scan_version": "0.0.13",
-    "ip": "192.30.253.113",
+    "ssh_scan_version": "0.0.17",
+    "ip": "192.30.253.112",
     "port": 22,
     "server_banner": "SSH-2.0-libssh-0.7.0",
     "ssh_version": 2.0,
@@ -9,7 +9,7 @@
     "os_cpe": "o:unknown",
     "ssh_lib": "libssh",
     "ssh_lib_cpe": "a:libssh:libssh",
-    "cookie": "41dab36bef4c686f0cb0d9f71f1d712b",
+    "cookie": "9914248c3ca6bae7ea1bbc149ff1a474",
     "key_algorithms": [
       "curve25519-sha256@libssh.org",
       "ecdh-sha2-nistp256",
@@ -71,10 +71,26 @@
       "publickey"
     ],
     "fingerprints": {
-      "md5": "f6:ce:1e:d1:87:52:2d:26:81:89:ec:e6:d3:8f:9f:69",
-      "sha1": "4d:b1:29:4f:e8:de:1c:14:1f:11:47:45:4e:8c:9a:c8:a8:45:76:40",
-      "sha256": "9e:16:bf:1a:99:1b:b9:f6:9a:f9:24:fd:b2:55:29:51:d8:d2:20:06:14:c8:03:b0:bf:bb:95:9a:d1:a7:83:0f"
+      "dsa": {
+        "known_bad": "false",
+        "md5": "ad:1c:08:a4:40:e3:6f:9c:f5:66:26:5d:4b:33:5d:8c",
+        "sha1": "74:91:97:3e:5f:8b:39:d5:32:7c:d4:e0:8b:c8:1b:05:f7:71:0b:49",
+        "sha256": "6e:bf:48:8c:5b:29:9b:5b:f1:47:78:80:df:91:56:13:ee:15:4f:2c:f5:85:85:4b:20:4d:ad:d7:f0:9e:c9:64"
+      },
+      "rsa": {
+        "known_bad": "false",
+        "md5": "16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48",
+        "sha1": "bf:6b:68:25:d2:97:7c:51:1a:47:5b:be:fb:88:aa:d5:4a:92:ac:73",
+        "sha256": "9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f"
+      }
     },
+    "start_time": "2017-03-21 01:05:16 -0400",
+    "end_time": "2017-03-21 01:05:17 -0400",
+    "scan_duration_seconds": 1.31775,
+    "duplicate_host_key_ips": [
+      "192.30.253.113",
+      "192.168.10.160"
+    ],
     "compliance": {
       "policy": "Mozilla Modern",
       "compliant": false,
@@ -90,9 +106,6 @@
       "references": [
         "https://wiki.mozilla.org/Security/Guidelines/OpenSSH"
       ]
-    },
-    "start_time": "2016-09-13 09:23:00 -0400",
-    "end_time": "2016-09-13 09:23:02 -0400",
-    "scan_duration_seconds": 2.312332
+    }
   }
 ]

--- a/lib/ssh_scan/crypto.rb
+++ b/lib/ssh_scan/crypto.rb
@@ -1,10 +1,22 @@
 require 'openssl'
+require 'sshkey'
 
 module SSHScan
   module Crypto
     class PublicKey
       def initialize(key)
         @key = key
+      end
+
+      # Is the current key known to be in our known bad key list
+      def bad_key?
+        SSHScan::Crypto.bad_public_keys.each do |other_key|
+          if self.fingerprint_sha256 == other_key.fingerprint_sha256
+            return true
+          end
+        end
+
+        return false
       end
 
       def fingerprint_md5
@@ -19,5 +31,18 @@ module SSHScan
         OpenSSL::Digest::SHA256.hexdigest(Base64.decode64(@key)).scan(/../).join(':')
       end
     end
+
+    def self.bad_public_keys
+      bad_keys = []
+
+      Dir.glob("data/ssh-badkeys/host/*.key").each do |file_path|
+        file = File.read(File.expand_path(file_path))
+        key = SSHKey.new(file)
+        bad_keys << SSHScan::Crypto::PublicKey.new(key.ssh_public_key.split[1])
+      end
+
+      return bad_keys
+    end
+
   end
 end

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -88,6 +88,7 @@ module SSHScan
             pkey = SSHScan::Crypto::PublicKey.new(host_keys[i + 1])
             result['fingerprints'].merge!({
               "dsa" => {
+                "known_bad" => pkey.bad_key?.to_s,
                 "md5" => pkey.fingerprint_md5,
                 "sha1" => pkey.fingerprint_sha1,
                 "sha256" => pkey.fingerprint_sha256,
@@ -99,6 +100,7 @@ module SSHScan
             pkey = SSHScan::Crypto::PublicKey.new(host_keys[i + 1])
             result['fingerprints'].merge!({
               "rsa" => {
+                "known_bad" => pkey.bad_key?.to_s,
                 "md5" => pkey.fingerprint_md5,
                 "sha1" => pkey.fingerprint_sha1,
                 "sha256" => pkey.fingerprint_sha256,

--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency('netaddr')
   s.add_dependency('net-ssh')
   s.add_dependency('sqlite3')
+  s.add_dependency('sshkey')
   s.add_development_dependency('pry')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
Fix #343 

This adds the known_bad fingerprints to the respective RSA/DSA grouping, like so making direct use of known bad host keys from https://github.com/rapid7/ssh-badkeys.  For testing, I just copied over my DSA host key and dropped it in the ssh-badkeys host folder with a .key extension to get it to load and test the new feature.

    "fingerprints": {
      "rsa": {
        "known_bad": "false",
        "md5": "46:7e:dd:ff:c9:14:d3:da:50:72:83:1a:77:73:5d:8f",
        "sha1": "ef:3f:94:fa:ad:e6:1d:b9:24:a4:30:79:4a:13:2e:74:48:71:a1:7e",
        "sha256": "49:5d:53:ce:d5:bf:e8:e9:b1:99:95:1a:20:96:a3:53:08:26:90:48:cc:ea:cf:57:7d:00:43:bc:ed:c0:ee:c0"
      },
      "dsa": {
        "known_bad": "true",
        "md5": "5d:80:de:85:af:fb:fc:ac:44:0f:b7:50:08:09:e7:d6",
        "sha1": "00:45:70:88:a5:2b:57:91:1a:0a:45:05:1b:fe:7a:51:15:0c:5c:3e",
        "sha256": "f9:9a:fa:d1:1a:96:36:00:cc:1a:76:4c:f5:ea:a1:1a:2e:41:ac:70:09:98:40:a1:2f:d8:0c:70:84:db:e5:cf"
      }
    },