### PR TITLE
Bump for 0.0.20 release

### DIFF
--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -226,25 +226,25 @@ unless File.exist?(options["policy"])
 end
 
 # Check to see if we're running the latest released version
-if !options["suppress_update_status"]
-  update = SSHScan::Update.new
-  if update.newer_gem_available?
-    options["logger"].warn(
-      "You're NOT using the latest version of ssh_scan, try 'gem update \
-ssh_scan' to get the latest"
-    )
-  else
-    if update.errors.any?
-      update.errors.each do |error|
-        options["logger"].error(error)
-      end
-    else
-      options["logger"].info(
-        "You're using the latest version of ssh_scan #{SSHScan::VERSION}"
-      )
-    end
-  end
-end
+#if !options["suppress_update_status"]
+#  update = SSHScan::Update.new
+#  if update.newer_gem_available?
+#    options["logger"].warn(
+#      "You're NOT using the latest version of ssh_scan, try 'gem update \
+#ssh_scan' to get the latest"
+#    )
+#  else
+#    if update.errors.any?
+#      update.errors.each do |error|
+#        options["logger"].error(error)
+#      end
+#    else
+#      options["logger"].info(
+#        "You're using the latest version of ssh_scan #{SSHScan::VERSION}"
+#      )
+#    end
+#  end
+#end
 
 # Limit scope of fingerprints DB to (per scan)
 if options["fingerprint_database"] && File.exists?(options["fingerprint_database"])

--- a/lib/ssh_scan/version.rb
+++ b/lib/ssh_scan/version.rb
@@ -1,3 +1,3 @@
 module SSHScan
-  VERSION = '0.0.19'
+  VERSION = '0.0.20'
 end


### PR DESCRIPTION
temporarily disabling update checks

Reasons:

- people with SSL configuration issues complain that it's an unnecessary blocker to perform an ssh_scan (and they are right)
- it actually slows down scans (~3sec before, ~1sec after) and I think that is significant in terms of perf

Maybe the above reasons are enough to make it not temporary but more long lasting, but I want to get something out to them sooner than later so they can get on with their scanning.