### PR TITLE
Restore travis docker pushes from branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     script:
       - docker build -t mozilla/ssh_scan .
       - >
-          if [ [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ]; then \
+          if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then \
             docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" ;\
             docker push mozilla/ssh_scan:latest ;\
           else \


### PR DESCRIPTION
Reverting this change as it had the unintended consequence of blocking docker push actions indefinately forcing people to be stuck on a specific build even when they were trying to update from the docker deployment strategy.