### PR TITLE
Bind to a specific version of netaddr

### DIFF
--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.metadata["yard.run"] = "yri" # use "yard" to build full HTML docs
 
   s.add_dependency('bindata', '~> 2.0')
-  s.add_dependency('netaddr')
+  s.add_dependency('netaddr', '1.5.1')
   s.add_dependency('net-ssh')
   s.add_dependency('sshkey')
   s.add_development_dependency('pry')


### PR DESCRIPTION
I ran into some problems with a deployment about netaddr not installing, I happened to notice I was rolling with netaddr 1.5.1 and 2.x was released today, so I think that's somehow related.  I may go and report that upstream once I get my thing fixed.