### PR TITLE
fix #432: Fix the regression present in v0.33

### DIFF
--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -125,9 +125,9 @@ module SSHScan
       begin
         Timeout::timeout(timeout) {
           stdin, stdout, stderr, wait_thr = Open3.popen3('ssh-keyscan', '-t', 'rsa,dsa', '-p', port.to_s, target)
-          output = stdout.gets(nil)
+          output = stdout.gets(nil) if port.nil?
           stdout.close
-          stderr.gets(nil)
+          output = stderr.gets(nil) if !port.nil?
           stderr.close
           exit_code = wait_thr.value
         }


### PR DESCRIPTION
ssh_keyscan is behaving weirdly when a port is passed to it as an
argument. By weird what I mean is instead of sending to output stdout it is
redirected to stderr. This is a temporary fix and it needs more
investigation why is that the case.

@claudijd  @jumanjiman