### PR TITLE
Bump CI ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,23 @@ matrix:
       - LABEL=unit_tests
     after_success:
       - coveralls
-  - rvm: 2.5.0
+  - rvm: 2.5.1
     env:
       - LABEL=unit_tests
-  - rvm: 2.4.3
-    env:
-      - LABEL=unit_tests
-  - rvm: 2.3.6
+  - rvm: 2.4.4
     env:
       - LABEL=unit_tests
   - rvm: 2.3.6
+    env:
+      - LABEL=unit_tests
+  - rvm: 2.5.1
+    env:
+      - LABEL=gem_integration_tests
+    script:
+      - gem install ssh_scan
+      - chmod 755 ./spec/ssh_scan/integration.sh
+      - ./spec/ssh_scan/integration.sh
+  - rvm: 2.4.4
     env:
       - LABEL=gem_integration_tests
     script:

--- a/lib/ssh_scan/version.rb
+++ b/lib/ssh_scan/version.rb
@@ -1,3 +1,3 @@
 module SSHScan
-  VERSION = '0.0.34'
+  VERSION = '0.0.35'
 end

--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('bindata', '~> 2.0')
   s.add_dependency('netaddr', '1.5.1')
-  s.add_dependency('net-ssh')
+  s.add_dependency('net-ssh', '~> 4.2')
   s.add_dependency('sshkey')
   s.add_development_dependency('pry')
   s.add_development_dependency('rspec', '~> 3.0')


### PR DESCRIPTION
Fixes an unbound dependency upper bound which can cause exceptions at net-ssh 5.x and adds more CI integration test coverage