### PR TITLE
Use alpine build for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:alpine
 MAINTAINER Jonathan Claudius
 ENV PROJECT=github.com/mozilla/ssh_scan
 
@@ -6,6 +6,13 @@ RUN mkdir /app
 ADD . /app
 WORKDIR /app
 
-RUN gem install bundler
-RUN bundle install
+# required for ssh-keyscan
+RUN apk --update add openssh-client
+
+RUN apk --update add --virtual build-dependencies ruby-dev build-base && \
+    gem install bundler --no-ri --no-rdoc && \
+    bundle install && \
+    apk del build-dependencies && \
+    rm -rf /var/cache/apk/*
+
 CMD /app/bin/ssh_scan

--- a/spec/ssh_scan/integration.sh
+++ b/spec/ssh_scan/integration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 command_exists () {
     type "$1" &> /dev/null ;


### PR DESCRIPTION
This PR proposes switching to an Alpine-based image base `ruby:alpine` instead of using the default Debian-based `ruby` build. The switch can allow the general users to enjoy a smaller Docker image.

On my testing box, the image shrank from 913MB to 93.1MB. 
