### PR TITLE
Add support for ecdsa and ed25519 keys

### DIFF
--- a/lib/ssh_scan/public_key.rb
+++ b/lib/ssh_scan/public_key.rb
@@ -20,6 +20,10 @@ module SSHScan
           return "rsa"
         elsif @key_string.start_with?("ssh-dss")
           return "dsa"
+        elsif @key_string.start_with?("ecdsa-sha2-nistp256")
+          return "ecdsa-sha2-nistp256"
+        elsif @key_string.start_with?("ssh-ed25519")
+          return "ed25519"
         else
           return "unknown"
         end 

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -123,7 +123,7 @@ module SSHScan
 
       output = ""
 
-      cmd = ['ssh-keyscan', '-t', 'rsa,dsa', '-p', port.to_s, target].join(" ")
+      cmd = ['ssh-keyscan', '-t', 'rsa,dsa,ecdsa,ed25519', '-p', port.to_s, target].join(" ")
 
       Utils::Subprocess.new(cmd) do |stdout, stderr, thread|
         if stdout
@@ -141,6 +141,16 @@ module SSHScan
         end
 
         if host_keys[i].eql? "ssh-rsa"
+          key = SSHScan::Crypto::PublicKey.new([host_keys[i], host_keys[i + 1]].join(" "))
+          keys.merge!(key.to_hash)
+        end
+
+        if host_keys[i].eql? "ecdsa-sha2-nistp256"
+          key = SSHScan::Crypto::PublicKey.new([host_keys[i], host_keys[i + 1]].join(" "))
+          keys.merge!(key.to_hash)
+        end
+
+        if host_keys[i].eql? "ssh-ed25519"
           key = SSHScan::Crypto::PublicKey.new([host_keys[i], host_keys[i + 1]].join(" "))
           keys.merge!(key.to_hash)
         end

--- a/spec/public_key_spec.rb
+++ b/spec/public_key_spec.rb
@@ -75,4 +75,61 @@ describe SSHScan::Crypto::PublicKey do
     end
   end
 
+  context "when parsing an ecdsa key string" do
+    it "should parse it and have the right values for each attribute" do
+      key_string = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyN" +
+                   "TYAAAAIbmlzdHAyNTYAAABBBC4gXA5naQtjcKu90NJ7A4jQ1U" +
+                   "gxYGdnndJyr4PSZJ59qJUzkoH3VgdTlseXbIZHwO4k2gNcFpa" +
+                   "Mq5gqVRobAwU="
+      key = SSHScan::Crypto::PublicKey.new(key_string)
+      expect(key).to be_kind_of SSHScan::Crypto::PublicKey
+      expect(key.valid?).to be true
+      expect(key.type).to eq("ecdsa-sha2-nistp256")
+      expect(key.length).to be 520
+      expect(key.fingerprint_md5).to eq("be:04:32:74:c6:63:fa:24:c3:c6:78:c2:cd:d2:3e:f4")
+      expect(key.fingerprint_sha1).to eq("00:67:e3:4d:78:2f:65:94:87:bf:54:5a:1e:92:af:67:0b:8d:b5:2c")
+      expect(key.fingerprint_sha256).to eq("EZe8ZoSwAzDOLR45H2PZ1aGGfnt59ZLrL5bwnjQwTUI=")
+      expect(key.to_hash).to eq(
+        {
+          "ecdsa-sha2-nistp256" => {
+            "fingerprints" => {
+              "md5"=>"be:04:32:74:c6:63:fa:24:c3:c6:78:c2:cd:d2:3e:f4",
+              "sha1"=>"00:67:e3:4d:78:2f:65:94:87:bf:54:5a:1e:92:af:67:0b:8d:b5:2c",
+              "sha256"=>"EZe8ZoSwAzDOLR45H2PZ1aGGfnt59ZLrL5bwnjQwTUI="
+            },
+            "length" => 520,
+            "raw" => "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC4gXA5naQtjcKu90NJ7A4jQ1UgxYGdnndJyr4PSZJ59qJUzkoH3VgdTlseXbIZHwO4k2gNcFpaMq5gqVRobAwU=",
+          }
+        }  
+      )
+    end
+  end
+
+  context "when parsing an ed25519 key string" do
+    it "should parse it and have the right values for each attribute" do
+      key_string = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINO+ybidO9DGOb1dDwyVvGcrCD/wILFWTYtWUQZVxXwH"
+      key = SSHScan::Crypto::PublicKey.new(key_string)
+      expect(key).to be_kind_of SSHScan::Crypto::PublicKey
+      expect(key.valid?).to be true
+      expect(key.type).to eq("ed25519")
+      expect(key.length).to be 256
+      expect(key.fingerprint_md5).to eq("0f:db:50:54:15:22:b3:6f:31:7c:ee:22:23:77:bc:77")
+      expect(key.fingerprint_sha1).to eq("32:d1:e8:50:ae:1c:cb:11:c5:09:fa:02:6e:f4:e8:dc:11:11:4c:48")
+      expect(key.fingerprint_sha256).to eq("p+P78wR61KZ4UvQZpr84EqslnRkhZ7txT1bN8vA/oHU=")
+      expect(key.to_hash).to eq(
+        {
+          "ed25519" => {
+            "fingerprints" => {
+              "md5"=>"0f:db:50:54:15:22:b3:6f:31:7c:ee:22:23:77:bc:77",
+              "sha1"=>"32:d1:e8:50:ae:1c:cb:11:c5:09:fa:02:6e:f4:e8:dc:11:11:4c:48",
+              "sha256"=>"p+P78wR61KZ4UvQZpr84EqslnRkhZ7txT1bN8vA/oHU="
+            },
+            "length" => 256,
+            "raw" => "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINO+ybidO9DGOb1dDwyVvGcrCD/wILFWTYtWUQZVxXwH",
+          }
+        }
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #486

Example output changes:

    "keys": {
      "ecdsa-sha2-nistp256": {
        "raw": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC4gXA5naQtjcKu90NJ7A4jQ1UgxYGdnndJyr4PSZJ59qJUzkoH3VgdTlseXbIZHwO4k2gNcFpaMq5gqVRobAwU=",
        "length": 520,
        "fingerprints": {
          "md5": "be:04:32:74:c6:63:fa:24:c3:c6:78:c2:cd:d2:3e:f4",
          "sha1": "00:67:e3:4d:78:2f:65:94:87:bf:54:5a:1e:92:af:67:0b:8d:b5:2c",
          "sha256": "EZe8ZoSwAzDOLR45H2PZ1aGGfnt59ZLrL5bwnjQwTUI="
        }
      },
      "rsa": {
        "raw": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCl/BNLUxR49+3AKqhf6sWKrh8XXzqXV00bEPFtcJFWxyRqC5pPWo9zRRiS2jitIcqljIQVohEEZHt48vZaA1hniVfe/FmrFzuCOuQOIP2fuRgLSNHu+lWVScsHoX/MuYXEIxj6aW7UpFn4lD01mvPtazXFO/tJ+LRs49YBP7UvL1smIS2xoyuH7kZDN17QG08YwbIB2fApMl8rXH+2Rpj5hlv+7rcZ1dqCGtmXmvsv8fKGYd7BxRy0s/d7EY4e/DeDxA1qTNV9BrBTNn6jAKIedTE5s4GNRbN/Q20mP2qmw70PiTGROw6xp9SBFA7N9hjjOT7iutK/pa7y1joXKjeJ",
        "length": 2048,
        "fingerprints": {
          "md5": "fc:c5:5b:0d:f0:c6:fd:fe:80:18:62:2c:05:38:20:8a",
          "sha1": "e1:3c:71:49:80:37:87:32:b5:0c:e3:86:41:ef:2e:2a:2f:14:e3:58",
          "sha256": "aH0wN2cs6x5Ktf9PvIzoQeFVqDBC4I484wq6vNv9XFA="
        }
      },
      "ed25519": {
        "raw": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINO+ybidO9DGOb1dDwyVvGcrCD/wILFWTYtWUQZVxXwH",
        "length": 256,
        "fingerprints": {
          "md5": "0f:db:50:54:15:22:b3:6f:31:7c:ee:22:23:77:bc:77",
          "sha1": "32:d1:e8:50:ae:1c:cb:11:c5:09:fa:02:6e:f4:e8:dc:11:11:4c:48",
          "sha256": "p+P78wR61KZ4UvQZpr84EqslnRkhZ7txT1bN8vA/oHU="
        }
      }
    },