### PR TITLE
Add rescue for ENOPROTOOPT errors

### DIFF
--- a/lib/ssh_scan/client.rb
+++ b/lib/ssh_scan/client.rb
@@ -70,6 +70,9 @@ module SSHScan
       rescue Errno::EHOSTUNREACH => e
         @error = SSHScan::Error::ConnectionRefused.new(e.message)
         @sock = nil
+      rescue Errno::ENOPROTOOPT => e
+        @error = SSHScan::Error::ConnectionRefused.new(e.message)
+        @sock = nil
       else
         if @raw_server_banner.nil?
           @error = SSHScan::Error::NoBanner.new(


### PR DESCRIPTION
Hello 👋
I was scanning a network with ssh_scan but was always crashing at the same host with the following error code:

```
/usr/local/lib/ruby/2.6.0/socket.rb:1213:in `__connect_nonblock': Protocol not available - connect(2) for 192.168.42.42:22 (Errno::ENOPROTOOPT)
        from /usr/local/lib/ruby/2.6.0/socket.rb:1213:in `connect_nonblock'
        from /usr/local/lib/ruby/2.6.0/socket.rb:56:in `connect_internal'
        from /usr/local/lib/ruby/2.6.0/socket.rb:137:in `connect'
        from /usr/local/lib/ruby/2.6.0/socket.rb:641:in `block in tcp'
        from /usr/local/lib/ruby/2.6.0/socket.rb:227:in `each'
        from /usr/local/lib/ruby/2.6.0/socket.rb:227:in `foreach'
        from /usr/local/lib/ruby/2.6.0/socket.rb:631:in `tcp'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/client.rb:48:in `block in connect'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:33:in `catch'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:33:in `catch'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/client.rb:47:in `connect'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/scan_engine.rb:75:in `scan_target'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/scan_engine.rb:184:in `block (2 levels) in scan'
/usr/local/lib/ruby/2.6.0/socket.rb:1213:in `__connect_nonblock': Protocol not available - connect(2) for 192.168.42.42:22 (Errno::ENOPROTOOPT)
        from /usr/local/lib/ruby/2.6.0/socket.rb:1213:in `connect_nonblock'
        from /usr/local/lib/ruby/2.6.0/socket.rb:56:in `connect_internal'
        from /usr/local/lib/ruby/2.6.0/socket.rb:137:in `connect'
        from /usr/local/lib/ruby/2.6.0/socket.rb:641:in `block in tcp'
        from /usr/local/lib/ruby/2.6.0/socket.rb:227:in `each'
        from /usr/local/lib/ruby/2.6.0/socket.rb:227:in `foreach'
        from /usr/local/lib/ruby/2.6.0/socket.rb:631:in `tcp'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/client.rb:48:in `block in connect'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:33:in `catch'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:33:in `catch'
        from /usr/local/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/client.rb:47:in `connect'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/scan_engine.rb:75:in `scan_target'
        from /usr/local/bundle/gems/ssh_scan-0.0.41/lib/ssh_scan/scan_engine.rb:184:in `block (2 levels) in scan'
```

I found that `client.rb` appeared to be missing a rescue block for `ENOPROTOOPT` error codes. If I am mistaken on that please do tell ;)

Wanted to add tests for the change, but didn't find any in https://github.com/mozilla/ssh_scan/blob/master/spec/ssh_scan/client_spec.rb so I skipped it for now.
