### PR TITLE
Fix 510: tweak Dockerfile to work around upstream environment issue with Ruby 2.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ WORKDIR /app
 # required for ssh-keyscan
 RUN apk --update add openssh-client
 
-RUN apk --update add --virtual build-dependencies ruby-dev build-base && \
-    gem install bundler && \
+ENV GEM_HOME /usr/local/bundle/ruby/2.7.0/
+ENV GEM_PATH /usr/local/bundle/ruby/2.7.0/
+
+RUN apk --update add --virtual build-dependencies build-base && \
     bundle install && \
-    apk del build-dependencies && \
+    apk del build-dependencies build-base && \
     rm -rf /var/cache/apk/*
 
 CMD /app/bin/ssh_scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 # required for ssh-keyscan
 RUN apk --update add openssh-client
 
-ENV GEM_HOME /usr/local/bundle/ruby/2.7.0/
+ENV GEM_HOME /usr/local/bundle/ruby/$RUBY_VERSION
 
 RUN apk --update add --virtual build-dependencies build-base && \
     bundle install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /app
 RUN apk --update add openssh-client
 
 ENV GEM_HOME /usr/local/bundle/ruby/2.7.0/
-ENV GEM_PATH /usr/local/bundle/ruby/2.7.0/
 
 RUN apk --update add --virtual build-dependencies build-base && \
     bundle install && \


### PR DESCRIPTION
## Overview

This PR resolves #510 by working around the non-apk-provided ruby 2.7.0 from `alpine:ruby` using environment variables.

I did the following:

- Redefined `GEM_HOME` from upstream to be accurate
- Removed `gem install bundler` as it is provided upstream in `/usr/local/bin`
- Added `build-base` to `apk del` to be symmetric with the temporary `apk add`

## Testing

There are no automated tests but I have manually verified that the following results in JSON output:

    $ docker build -t ssh_scan .
    $ docker run -it ssh_scan /app/bin/ssh_scan -t sshscan.rubidus.com
    [...]

## Additional steps

A better way to fix this may be to submit an upstream PR to the maintainers of `alpine:ruby` so that they can set the correct `GEM_*` environment variables according to the source-built version of ruby they choose to use.

For now, however, I believe this will correct the issue as reported.