### PR TITLE
Fix Docker Hub build and deploy script to fail the job 

### DIFF
--- a/build_and_deploy_to_dockerhub.sh
+++ b/build_and_deploy_to_dockerhub.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 docker build -t mozilla/ssh_scan .
 
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then


### PR DESCRIPTION
# Description

Fail the TravisCI build if there is an error in the script _build_and_deploy_to_dockerhub.sh_.

**What I expected:**
```
To install the missing version, run `gem install bundler:1.17.3`
	from /usr/local/lib/ruby/2.7.0/rubygems.rb:296:in `activate_bin_path'
	from /usr/local/bin/bundle:23:in `<main>'
The command '/bin/sh -c apk --update add --virtual build-dependencies build-base &&     bundle install &&     apk del build-dependencies build-base &&     rm -rf /var/cache/apk/*' returned a non-zero code: 1
The command "./build_and_deploy_to_dockerhub.sh" exited with 1.

Done. Your build exited with 1.
```

**What happened:**

Although the pipeline / job status reports success since the script is ignoring the errors.

```
The command '/bin/sh -c apk --update add --virtual build-dependencies build-base &&     bundle install &&     apk del build-dependencies build-base &&     rm -rf /var/cache/apk/*' returned a non-zero code: 1
The command "./build_and_deploy_to_dockerhub.sh" exited with 0.

Done. Your build exited with 0.
```
