### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM ruby:2.7.2-alpine3.12
 MAINTAINER Jonathan Claudius
 ENV PROJECT=github.com/mozilla/ssh_scan
 
-RUN mkdir /app
-ADD . /app
 WORKDIR /app
+ADD . /app
 
 # required for ssh-keyscan
 RUN apk --update add openssh-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN apk --update add --virtual build-dependencies build-base && \
     apk del build-dependencies build-base && \
     rm -rf /var/cache/apk/*
 
-CMD /app/bin/ssh_scan
+ENTRYPOINT [ "/app/bin/ssh_scan" ]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run from a docker container, type:
 
 ```bash
 docker pull mozilla/ssh_scan
-docker run -it mozilla/ssh_scan /app/bin/ssh_scan -t sshscan.rubidus.com
+docker run -it mozilla/ssh_scan -t sshscan.rubidus.com
 ```
 
 To install and run from source, type:


### PR DESCRIPTION
I made a small tweak to the Dockerfile to make running ssh_scan from a container easier. Now instead of

```
docker run -it mozilla/ssh_scan /app/bin/ssh_scan -t sshscan.rubidus.com
```

it's just

```
docker run -it mozilla/ssh_scan -t sshscan.rubidus.com
```